### PR TITLE
Fix Netlify build path

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BUILD_PATH=dist

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 
 ### `npm run build`
 
-Builds the app for production to the `build` folder.\
+Builds the app for production to the `dist` folder.\
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
 The build is minified and the filenames include the hashes.\


### PR DESCRIPTION
## Summary
- set `BUILD_PATH` so `npm run build` outputs to `dist`
- document the new `dist` output directory

## Testing
- `npm run build`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6878b0852fa483239962dec25a0cfe43