### PR TITLE
Revamp homepage with new layout

### DIFF
--- a/src/components/components/contact.js
+++ b/src/components/components/contact.js
@@ -53,23 +53,6 @@ const Contact = () => {
             </Helmet>
 
             <div>
-                <div className={"bg-dark p-3"}>
-                    <nav className="pt-3 navbar navbar-expand-lg navbar-dark">
-                        <ul className="navbar-nav d-flex" style={{ listStyleType: 'none', margin: 0, padding: 0 }}>
-                            <li className="nav-item">
-                                <strong>
-                                    <a className="nav-link text-white" href="/" style={{ fontSize: '1.2rem', marginRight: '15px' }}>Home</a>
-                                </strong>
-                            </li>
-                            <li className="nav-item">
-                                <strong>
-                                    <a className="nav-link text-white" href="/contacto" style={{ fontSize: '1.2rem' }}>Contacto</a>
-                                </strong>
-                            </li>
-                        </ul>
-                    </nav>
-                </div>
-
                 <section className={"container pt-5"}>
                     <h1 className="text-center mb-4">Contacto</h1>
                     <p className="text-center text-muted">

--- a/src/components/components/header.js
+++ b/src/components/components/header.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Navbar, Nav, Container } from 'react-bootstrap';
+import logoImage from '../img/LOGO(Fondo Transparent).png';
+
+const Header = () => (
+  <Navbar bg="primary" variant="dark" expand="lg" className="py-3">
+    <Container>
+      <Navbar.Brand href="/">
+        <img src={logoImage} alt="JCT Agency" style={{ height: '40px' }} />
+      </Navbar.Brand>
+      <Navbar.Toggle aria-controls="main-navbar" />
+      <Navbar.Collapse id="main-navbar">
+        <Nav className="ms-auto">
+          <Nav.Link href="/">Home</Nav.Link>
+          <Nav.Link href="/contacto">Contacto</Nav.Link>
+        </Nav>
+      </Navbar.Collapse>
+    </Container>
+  </Navbar>
+);
+
+export default Header;

--- a/src/components/components/home.js
+++ b/src/components/components/home.js
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 import Layout from "../layouts/layout";
-import LogoJCT from "../img/LOGO(Fondo Transparent).png";
 import WebPhoto from "../img/WebPho.jpeg";
 import AveroImage from "../img/bossacompra.png";
+import fondoHome from "../img/fondoHome.jpg";
+import portatilIcon from "../img/portatilIcon.png";
+import movilIcon from "../img/movilIcon.jpeg";
+import lapizIcon from "../img/lapizIcon.jpeg";
 import { Helmet } from "react-helmet";
 import emailjs from "emailjs-com";
 
@@ -35,76 +38,71 @@ const Home = () => {
           content="JCT Agency desarrolla soluciones de software empresarial y servicios a medida."
         />
       </Helmet>
-      <div className="d-flex flex-column bg-jct-blue">
-        {/* Banner */}
-        <section className="container">
-          <div>
-            <nav className="pt-3 navbar navbar-expand-lg navbar-dark bg-jct-blue">
-              <ul className="navbar-nav d-flex" style={{ listStyleType: 'none', margin: 0, padding: 0 }}>
-                <li className="nav-item">
-                  <strong>
-                    <a className="nav-link text-white" href="/" style={{ fontSize: '1.2rem', marginRight: '15px' }}>
-                      Home
-                    </a>
-                  </strong>
-                </li>
-                <li className="nav-item">
-                  <strong>
-                    <a className="nav-link text-white" href="/contacto" style={{ fontSize: '1.2rem' }}>
-                      Contacto
-                    </a>
-                  </strong>
-                </li>
-              </ul>
-            </nav>
-          </div>
-
-          <div className="d-flex align-items-center text-white justify-content-between" style={{ height: '40vh' }}>
-            <div>
-              <img style={{ maxWidth: '50%', height: 'auto' }} src={LogoJCT} alt="Logo JCT Agency" />
-            </div>
-            <div>
-              <h1 className="pb-3">JCT Agency</h1>
-              <h2 className="text-white">Software empresarial y desarrollo a medida</h2>
-            </div>
+      <div className="d-flex flex-column">
+        {/* Hero */}
+        <section
+          className="hero d-flex align-items-center text-white text-center"
+          style={{
+            backgroundImage: `url(${fondoHome})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            height: '70vh'
+          }}
+        >
+          <div className="container">
+            <h1 className="display-4 fw-bold">JCT Agency</h1>
+            <p className="lead">Software empresarial i solucions digitals a mida</p>
+            <a href="/contacto" className="btn btn-light mt-3">Contacta'ns</a>
           </div>
         </section>
 
         {/* Sobre nosotros */}
-        <section className="container-fluid bg-white p-5 text-black">
-          <div className="container">
-            <h2 className="mb-4">Sobre Nosotros</h2>
-            <p>
-              En JCT Agency ajudem a digitalitzar i optimitzar processos amb eines de software adaptades al teu negoci.
-              Apostem per la innovació constant i el treball proper amb els nostres clients per aconseguir resultats de qualitat.
-              Desenvolupem projectes a mida, des de webs corporatives fins a solucions d'automatització interna.
-            </p>
-            <img className="img-fluid rounded my-3" src={WebPhoto} alt="Projectes en desenvolupament" />
+        <section className="container py-5">
+          <div className="row align-items-center g-4">
+            <div className="col-md-6">
+              <h2 className="mb-4">Sobre nosaltres</h2>
+              <p>
+                A JCT Agency impulsem la digitalització del teu negoci mitjançant eines de software a mida.
+                Treballem colze a colze amb tu per aconseguir resultats d'alta qualitat i processos més eficients.
+              </p>
+              <p>Som especialistes en desenvolupament web, aplicacions i integració de sistemes empresarials.</p>
+            </div>
+            <div className="col-md-6 text-center">
+              <img className="img-fluid rounded" src={WebPhoto} alt="Projectes en desenvolupament" />
+            </div>
           </div>
         </section>
 
         {/* Servicios */}
-        <section className="bg-light">
-          <div className="container p-5">
-            <h2 className="text-center text-dark mb-4">Serveis</h2>
-            <p>
-              Oferim solucions integrals perquè la teva empresa pugui treure el màxim rendiment de la tecnologia. Ens especialitzem en:
-            </p>
-            <ul>
-              <li><strong>Desenvolupament Web</strong>: creació i manteniment de portals moderns i aplicacions progressives.</li>
-              <li><strong>Aplicacions Mòbils</strong>: dissenyem apps nadiues i multiplataforma preparades per a les botigues oficials.</li>
-              <li><strong>Programari a Mida</strong>: ERP i sistemes de gestió personalitzats amb integració d'APIs externes.</li>
-            </ul>
-            <p className="mt-3">Donem suport complet durant tot el cicle de vida del projecte i t'assessorem per assolir els teus objectius digitals.</p>
+        <section className="bg-light py-5">
+          <div className="container">
+            <h2 className="text-center mb-4">Serveis</h2>
+            <div className="row g-4 text-center">
+              <div className="col-md-4">
+                <img src={portatilIcon} alt="Desenvolupament web" style={{ width: '60px' }} className="mb-3" />
+                <h5>Desenvolupament Web</h5>
+                <p>Creació i manteniment de portals moderns i apps progressives.</p>
+              </div>
+              <div className="col-md-4">
+                <img src={movilIcon} alt="Aplicacions mòbils" style={{ width: '60px' }} className="mb-3" />
+                <h5>Aplicacions Mòbils</h5>
+                <p>Disseny d'apps nadiues i multiplataforma per a les botigues oficials.</p>
+              </div>
+              <div className="col-md-4">
+                <img src={lapizIcon} alt="Programari a mida" style={{ width: '60px' }} className="mb-3" />
+                <h5>Programari a Mida</h5>
+                <p>Sistemes de gestió integrats i personalitzats amb APIs externes.</p>
+              </div>
+            </div>
           </div>
         </section>
 
         {/* Línea Avero */}
-        <section className="container p-5 bg-avero">
-          <h2 className="text-center mb-4">Línia AVERO</h2>
+        <section className="container py-5 bg-avero text-center">
+          <h2 className="mb-4">Línia AVERO</h2>
           <p>
-            Solucions de facturació amb <strong>Verifactu</strong> integrades directament al teu negoci. Pròximament
-            incorporarem el mòdul de comptabilitat.
+            Solucions de facturació amb <strong>Verifactu</strong> integrades directament al teu negoci.
+            Properament incorporarem el mòdul de comptabilitat.
           </p>
           <img className="img-fluid rounded mb-3" src={AveroImage} alt="Facturació Avero" />
           <div className="text-center">

--- a/src/components/layouts/layout.js
+++ b/src/components/layouts/layout.js
@@ -1,42 +1,28 @@
 import React from 'react';
+import Header from '../components/header';
 import logoImage from '../img/LOGO(Fondo Transparent).png';
-// import logoImage2 from '../img/phoenixlogo2.png';
 
+const Layout = ({ children }) => (
+  <>
+    <Header />
+    <main>{children}</main>
+    <footer className="pt-5 bg-dark text-white pb-3">
+      <div className="container d-flex align-items-center justify-content-between pb-3">
+        <div className="col-md-3 w-25">
+          <img className="navbar-logo w-50" src={logoImage} alt="Logo JCT Agency" />
+        </div>
+        <div className="col-md-3 w-25">
+          <h5>Contacto</h5>
+          <p>Dirección: Online</p>
+          <p>Email: joan@jctagency.com</p>
+          <p>Teléfono: 633 391 411</p>
+        </div>
+      </div>
+      <div className="text-center">
+        <p>© 2024 JCT Agency.</p>
+      </div>
+    </footer>
+  </>
+);
 
-const Layout = ({children}) => {
-
-    return (
-        <>
-
-
-
-            <main>{children}</main>
-
-
-            <footer className={"pt-5 bg-dark text-white pb-3"}  >
-                <div className="container d-flex align-items-center justify-content-between pb-3">
-                    <div className="col-md-3 w-25">
-                        <img className="navbar-logo w-50" src={logoImage} alt="Logo JCT Agency"/>
-                    </div>
-                    <div className="col-md-3 w-25">
-
-                        <h5>Contacto</h5>
-                        <p>Dirección: Online</p>
-                        <p>Email: joan@jctagency.com</p>
-                        <p>Teléfono: 633 391 411</p>
-                    </div>
-
-                    {/* Enlaces a las páginas importantes */}
-
-                </div>
-                <div className={"text-center "}>
-                    <p>
-                       © 2024 JCT Agency.
-                    </p>
-                </div>
-
-            </footer>
-        </>
-            );
-};
-            export default Layout;
+export default Layout;


### PR DESCRIPTION
## Summary
- add reusable Header component
- integrate Header and modernize layout
- revamp Home page sections with hero, about, services and improved AVERO info
- simplify Contact page by removing duplicated nav

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878c08fa8b8832385d567a76e0939e1