### PR TITLE
feat: refresh home content and footer

### DIFF
--- a/src/components/components/home.js
+++ b/src/components/components/home.js
@@ -3,12 +3,18 @@ import Layout from "../layouts/layout";
 import { Helmet } from "react-helmet";
 import emailjs from "emailjs-com";
 
-import QuiSomImage from "../img/QUI SOM.png";
-import AveroLogo from "../img/AVERO LOGO.png";
+import heroImg from "../img/contactIcon.jpeg";
+import autonomIcon from "../img/portatilIcon.png";
+import pimesIcon from "../img/bossacompra.png";
+import gestoriesIcon from "../img/infoIcon.jpeg";
+
 import softwareImg from "../img/DESENVOLUPAMENT SOFTWARE.png";
 import consultoriesImg from "../img/CONSULTORIES.png";
 import dissenyWebImg from "../img/DISENY PAGINES WEB.png";
 import suportImg from "../img/SUPORT.png";
+
+import AveroLogo from "../img/AVERO LOGO.png";
+
 import confiancaImg from "../img/CONFIANÇA.png";
 import eficienciaImg from "../img/EFICIENCIA.png";
 import escalabilitatImg from "../img/ESCALABILITAT.png";
@@ -44,229 +50,261 @@ const Home = () => {
         <title>JCT Agency | Solucions digitals per fer créixer el teu negoci</title>
         <meta
           name="description"
-          content="Desenvolupem programari empresarial modern, intuïtiu i segur."
+          content="Som una agència tecnològica especialitzada en software SaaS i programari empresarial."
         />
       </Helmet>
 
       <div className="bg-white text-dark">
-        {/* Claim principal */}
-        <section className="py-5 text-center">
+        {/* Hero */}
+        <section className="py-5">
           <div className="container">
-            <h1 className="display-5 fw-bold">
-              JCT Agency – Solucions digitals per fer créixer el teu negoci
-            </h1>
-            <p className="lead">Desenvolupem programari empresarial modern, intuïtiu i segur.</p>
-            <p>
-              Ajudem autònoms, PIMEs i gestories a simplificar la gestió diària amb
-              software adaptat a les seves necessitats i al marc legal vigent.
-            </p>
-            <div className="d-flex justify-content-center gap-3 mt-4">
-              <a href="#serveis" className="btn btn-primary">
-                ➡️ Coneix els nostres serveis
-              </a>
-              <a href="/contacto" className="btn btn-outline-primary">
-                ➡️ Parla amb nosaltres
-              </a>
+            <div className="row align-items-center g-4 flex-column flex-md-row">
+              <div className="col-md-6">
+                <h1>JCT Agency – Solucions digitals per a autònoms, PIMEs i gestories</h1>
+                <p>
+                  Som una agència tecnològica especialitzada en <strong>software SaaS</strong> i
+                  <strong> programari empresarial</strong> que simplifica la gestió i garanteix el
+                  <strong> compliment legal amb Veri*Factu</strong>.
+                </p>
+                <div className="d-flex gap-3 mt-3">
+                  <a href="#serveis" className="btn btn-primary">
+                    Descobreix els nostres serveis
+                  </a>
+                  <a href="#contacte" className="btn btn-outline-primary">
+                    Parla amb nosaltres
+                  </a>
+                </div>
+              </div>
+              <div className="col-md-6 text-center">
+                <img
+                  src={heroImg}
+                  alt="Handshake"
+                  className="img-fluid"
+                  style={{ maxWidth: "300px" }}
+                />
+              </div>
             </div>
           </div>
         </section>
 
-        {/* Qui som */}
-        <section id="qui-som" className="py-5">
+        {/* Clients */}
+        <section id="clients" className="py-5 bg-light">
           <div className="container">
-            <div className="row align-items-center g-4">
-              <div className="col-md-6">
-                <h2 className="mb-4">Qui som</h2>
-                <p>
-                  A JCT Agency som una agència tecnològica especialitzada en
-                  solucions empresarials i software SaaS.
-                </p>
-                <p>El nostre objectiu és doble:</p>
-                <ul>
-                  <li>
-                    Acompanyar autònoms i PIMEs en la seva digitalització amb
-                    eines simples i fiables.
-                  </li>
-                  <li>
-                    Ser el partner tecnològic de confiança de les gestories,
-                    oferint eines que els permetin créixer i aportar més valor
-                    als seus clients.
-                  </li>
-                </ul>
-                <p>Valors que ens defineixen:</p>
-                <ul>
-                  <li>
-                    <strong>Innovació</strong> → sempre a l’avantguarda en
-                    tecnologia i normatives.
-                  </li>
-                  <li>
-                    <strong>Simplicitat</strong> → software intuïtiu que
-                    facilita el treball, no el complica.
-                  </li>
-                  <li>
-                    <strong>Compliment legal i seguretat</strong> → desenvolupem
-                    sistemes totalment adaptats a Veri*Factu i altres obligacions
-                    normatives.
-                  </li>
-                  <li>
-                    <strong>Proximitat i suport</strong> → ens involucrem en els
-                    projectes dels nostres clients.
-                  </li>
-                </ul>
+            <h2 className="text-center mb-4">Ajudem empreses com la teva</h2>
+            <p className="text-center">
+              El nostre software està pensat per a <strong>autònoms</strong>, <strong>PIMEs</strong> i
+              <strong> gestories</strong> que volen digitalitzar-se sense complicacions.
+            </p>
+            <div className="row mt-4">
+              <div className="col-md-4 text-center mb-4">
+                <img src={autonomIcon} alt="Autònoms" style={{ width: "60px" }} className="mb-3" />
+                <h5>Autònoms</h5>
+                <p>Solucions adaptades als professionals independents.</p>
               </div>
-              <div className="col-md-6 text-center">
+              <div className="col-md-4 text-center mb-4">
+                <img src={pimesIcon} alt="PIMEs" style={{ width: "60px" }} className="mb-3" />
+                <h5>PIMEs</h5>
+                <p>Eines modernes per optimitzar la gestió empresarial.</p>
+              </div>
+              <div className="col-md-4 text-center mb-4">
                 <img
-                  src={QuiSomImage}
-                  alt="Equip JCT Agency"
-                  className="img-fluid rounded"
+                  src={gestoriesIcon}
+                  alt="Gestories"
+                  style={{ width: "60px" }}
+                  className="mb-3"
                 />
+                <h5>Gestories</h5>
+                <p>Programari que facilita nous serveis digitals als clients.</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Serveis */}
-        <section id="serveis" className="py-5 bg-light">
+        <section id="serveis" className="py-5">
           <div className="container">
-            <h2 className="text-center mb-4">Serveis</h2>
-            <div className="row g-4">
-              <div className="col-md-3 text-center">
+            <h2 className="text-center mb-4">Els nostres serveis</h2>
+            <p className="text-center mb-5">
+              A JCT Agency oferim serveis digitals per impulsar el creixement i l’eficiència del teu
+              negoci.
+            </p>
+            <div className="row row-cols-1 row-cols-md-2 g-4">
+              <div className="col text-center">
                 <img
                   src={softwareImg}
                   alt="Desenvolupament de software empresarial"
                   style={{ width: "60px" }}
                   className="mb-3"
                 />
-                <h5>Desenvolupament de software empresarial</h5>
+                <h3>Desenvolupament de software empresarial</h3>
                 <p>
-                  Creació de programes propis, solucions SaaS i integracions amb
-                  serveis externs.
+                  Creem <strong>programari propi</strong>, <strong>solucions SaaS</strong> i
+                  <strong> integracions amb serveis externs</strong> perquè la teva empresa treballi amb
+                  eines modernes i segures.
                 </p>
+                <a href="#contacte" className="btn btn-link">
+                  Més informació
+                </a>
               </div>
-              <div className="col-md-3 text-center">
+              <div className="col text-center">
                 <img
                   src={consultoriesImg}
                   alt="Consultoria tecnològica i legal"
                   style={{ width: "60px" }}
                   className="mb-3"
                 />
-                <h5>Consultoria tecnològica i legal</h5>
+                <h3>Consultoria tecnològica i legal</h3>
                 <p>
-                  Assessorament en noves normatives i estratègia de
-                  digitalització.
+                  T’assessorem en <strong>noves normatives</strong>, <strong>estratègies de digitalització</strong> i
+                  compliment amb <strong>Veri*Factu</strong>, perquè estiguis sempre a l’avantguarda.
                 </p>
+                <a href="#contacte" className="btn btn-link">
+                  Més informació
+                </a>
               </div>
-              <div className="col-md-3 text-center">
+              <div className="col text-center">
                 <img
                   src={dissenyWebImg}
                   alt="Disseny i manteniment web"
                   style={{ width: "60px" }}
                   className="mb-3"
                 />
-                <h5>Disseny i manteniment web</h5>
+                <h3>Disseny i manteniment web</h3>
                 <p>
-                  Creació i gestió de webs corporatives, actualitzacions i
-                  seguretat.
+                  Creem i gestionem <strong>webs corporatives</strong> modernes, amb <strong>manteniment constant</strong>,
+                  actualitzacions i seguretat garantida.
                 </p>
+                <a href="#contacte" className="btn btn-link">
+                  Més informació
+                </a>
               </div>
-              <div className="col-md-3 text-center">
-                <img
-                  src={suportImg}
-                  alt="Suport continuat"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h5>Suport continuat</h5>
-                <p>Atenció propera i evolució constant del software.</p>
+              <div className="col text-center">
+                <img src={suportImg} alt="Suport continuat" style={{ width: "60px" }} className="mb-3" />
+                <h3>Suport continuat</h3>
+                <p>
+                  Ens involucrem en els teus projectes amb <strong>atenció propera</strong> i
+                  <strong> evolució constant del software</strong>, perquè el teu negoci mai s’aturi.
+                </p>
+                <a href="#contacte" className="btn btn-link">
+                  Més informació
+                </a>
               </div>
             </div>
           </div>
         </section>
 
-        {/* Productes propis */}
-        <section id="productes" className="py-5">
+        {/* Avero */}
+        <section id="avero" className="py-5 bg-light">
           <div className="container">
-            <h2 className="text-center mb-4">Productes propis</h2>
             <div className="row align-items-center g-4">
-              <div className="col-md-6 text-center">
-                <img
-                  src={AveroLogo}
-                  alt="Avero"
-                  className="img-fluid rounded"
-                />
-              </div>
               <div className="col-md-6">
-                <h3>Avero – Facturació moderna i segura</h3>
+                <h2>Avero – Facturació moderna i segura</h2>
                 <p>
-                  Un software SaaS que simplifica la facturació d’autònoms i
-                  PIMEs, i garanteix el compliment legal amb Veri*Factu.
+                  <strong>Avero</strong> és el nostre <strong>software SaaS de facturació</strong>, pensat per a
+                  <strong> autònoms i PIMEs</strong>. Et permet gestionar <strong>factures, pressupostos, albarans i TPV</strong>
+                  de forma simple, amb <strong>enviament automàtic a l’AEAT</strong> i total compliment legal amb
+                  <strong> Veri*Factu</strong>.
                 </p>
-                <p>
-                  Funcionalitats: factures, pressupostos, albarans, TPV, enviament
-                  automàtic a l’AEAT, gestió de clients i productes.
-                </p>
+                <ul>
+                  <li>Facturació electrònica completa i segura</li>
+                  <li>Pressupostos, albarans i TPV integrats</li>
+                  <li>Gestió de clients i productes</li>
+                  <li>Compliment normatiu amb Veri*Factu</li>
+                </ul>
+                <a href="/avero" className="btn btn-primary">
+                  Coneix Avero
+                </a>
+              </div>
+              <div className="col-md-6 text-center">
+                <img src={AveroLogo} alt="Avero" className="img-fluid" style={{ maxWidth: "300px" }} />
               </div>
             </div>
           </div>
         </section>
 
-        {/* Què aportem */}
-        <section id="aportem" className="py-5 bg-light">
+        {/* Beneficis */}
+        <section id="beneficis" className="py-5">
           <div className="container">
             <h2 className="text-center mb-4">Què aportem als nostres clients</h2>
-            <div className="row g-4">
-              <div className="col-md-3 text-center">
-                <img
-                  src={confiancaImg}
-                  alt="Confiança"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h5>Confiança</h5>
-                <p>Treballem perquè compleixin amb la normativa sense maldecaps.</p>
+            <div className="row row-cols-2 row-cols-md-4 g-4">
+              <div className="col text-center">
+                <img src={confiancaImg} alt="Confiança" style={{ width: "60px" }} className="mb-3" />
+                <h3>Confiança</h3>
+                <p>
+                  Treballem perquè compleixis amb la normativa sense maldecaps, amb <strong>solucions fiables i segures</strong>.
+                </p>
               </div>
-              <div className="col-md-3 text-center">
-                <img
-                  src={eficienciaImg}
-                  alt="Eficiència"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h5>Eficiència</h5>
-                <p>Estalvi de temps i simplificació de processos.</p>
+              <div className="col text-center">
+                <img src={eficienciaImg} alt="Eficiència" style={{ width: "60px" }} className="mb-3" />
+                <h3>Eficiència</h3>
+                <p>
+                  Optimitza el teu temps amb <strong>processos simplificats</strong> i un software intuïtiu.
+                </p>
               </div>
-              <div className="col-md-3 text-center">
+              <div className="col text-center">
                 <img
                   src={escalabilitatImg}
                   alt="Escalabilitat"
                   style={{ width: "60px" }}
                   className="mb-3"
                 />
-                <h5>Escalabilitat</h5>
-                <p>Solucions pensades per créixer amb el negoci.</p>
+                <h3>Escalabilitat</h3>
+                <p>Les nostres solucions creixen amb el teu negoci, adaptant-se a noves necessitats.</p>
               </div>
-              <div className="col-md-3 text-center">
+              <div className="col text-center">
                 <img
                   src={aliancesImg}
                   alt="Aliances estratègiques"
                   style={{ width: "60px" }}
                   className="mb-3"
                 />
-                <h5>Aliances estratègiques</h5>
-                <p>Oferim a les gestories eines que generen nous ingressos.</p>
+                <h3>Aliances estratègiques</h3>
+                <p>
+                  Oferim a les <strong>gestories</strong> eines que obren <strong>nous canals d’ingressos</strong> i milloren el servei als seus clients.
+                </p>
               </div>
             </div>
+          </div>
+        </section>
+
+        {/* Valors */}
+        <section id="valors" className="py-5 bg-light">
+          <div className="container">
+            <h2 className="text-center mb-4">Els nostres valors</h2>
+            <p className="text-center">
+              A JCT Agency treballem amb una filosofia clara: oferir <strong>innovació, simplicitat, seguretat i proximitat</strong>.
+            </p>
+            <ul className="list-unstyled row g-4 mt-4">
+              <li className="col-md-3">
+                <strong>Innovació</strong> – sempre a l’avantguarda tecnològica i legal.
+              </li>
+              <li className="col-md-3">
+                <strong>Simplicitat</strong> – software intuïtiu que facilita el treball, no el complica.
+              </li>
+              <li className="col-md-3">
+                <strong>Compliment legal i seguretat</strong> – desenvolupem sistemes totalment adaptats a Veri*Factu i altres normatives.
+              </li>
+              <li className="col-md-3">
+                <strong>Proximitat i suport</strong> – ens involucrem en cada projecte com si fos nostre.
+              </li>
+            </ul>
           </div>
         </section>
 
         {/* Blog / Recursos */}
         <section id="blog" className="py-5">
           <div className="container">
-            <h2 className="text-center mb-4">Blog / Recursos</h2>
+            <h2 className="text-center mb-4">Recursos i guies útils</h2>
             <ul className="list-unstyled">
-              <li>“Com digitalitzar la gestió d’una PIME en 5 passos”</li>
-              <li>“Guia pràctica per a gestories sobre Veri*Factu”</li>
-              <li>“Per què un SaaS és millor que un software tradicional?”</li>
+              <li>
+                <a href="/blog/digitalitzar-pime">Com digitalitzar la gestió d’una PIME en 5 passos</a>
+              </li>
+              <li>
+                <a href="/blog/verifactu-gestories">Guia pràctica per a gestories sobre Veri*Factu</a>
+              </li>
+              <li>
+                <a href="/blog/saas-vs-tradicional">Per què un SaaS és millor que un software tradicional?</a>
+              </li>
             </ul>
           </div>
         </section>
@@ -274,78 +312,62 @@ const Home = () => {
         {/* Contacte */}
         <section id="contacte" className="py-5 bg-light">
           <div className="container">
-            <h2 className="text-center mb-4">Contacte</h2>
             <div className="row g-4">
               <div className="col-md-6">
-                <p>Parlem del teu projecte?</p>
-                <p>📧 Correu: info@jctagency.com</p>
-                <p>📍 Ubicació: [ciutat/província]</p>
-                <p>📱 Xarxes socials (LinkedIn, etc.)</p>
+                <h2>Parlem del teu projecte?</h2>
+                <p>Si busques un partner tecnològic per digitalitzar la teva empresa, contacta amb nosaltres.</p>
+                <form onSubmit={handleSubmit}>
+                  <input
+                    type="text"
+                    name="nom"
+                    placeholder="Nom i cognoms"
+                    className="form-control mb-3"
+                    value={formFields.nom}
+                    onChange={handleChange}
+                    required
+                  />
+                  <input
+                    type="text"
+                    name="empresa"
+                    placeholder="Empresa"
+                    className="form-control mb-3"
+                    value={formFields.empresa}
+                    onChange={handleChange}
+                  />
+                  <input
+                    type="email"
+                    name="email"
+                    placeholder="Email"
+                    className="form-control mb-3"
+                    value={formFields.email}
+                    onChange={handleChange}
+                    required
+                  />
+                  <textarea
+                    name="missatge"
+                    placeholder="Missatge"
+                    className="form-control mb-3"
+                    rows="4"
+                    value={formFields.missatge}
+                    onChange={handleChange}
+                    required
+                  ></textarea>
+                  <button type="submit" className="btn btn-primary">
+                    Enviar missatge
+                  </button>
+                  {isFormSubmitted && <p className="mt-3">¡Missatge enviat!</p>}
+                </form>
               </div>
               <div className="col-md-6">
-                <form onSubmit={handleSubmit}>
-                  <div className="mb-3">
-                    <label htmlFor="nom" className="form-label">
-                      Nom i cognoms
-                    </label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      id="nom"
-                      name="nom"
-                      value={formFields.nom}
-                      onChange={handleChange}
-                      required
-                    />
-                  </div>
-                  <div className="mb-3">
-                    <label htmlFor="empresa" className="form-label">
-                      Empresa
-                    </label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      id="empresa"
-                      name="empresa"
-                      value={formFields.empresa}
-                      onChange={handleChange}
-                    />
-                  </div>
-                  <div className="mb-3">
-                    <label htmlFor="email" className="form-label">
-                      Email
-                    </label>
-                    <input
-                      type="email"
-                      className="form-control"
-                      id="email"
-                      name="email"
-                      value={formFields.email}
-                      onChange={handleChange}
-                      required
-                    />
-                  </div>
-                  <div className="mb-3">
-                    <label htmlFor="missatge" className="form-label">
-                      Missatge
-                    </label>
-                    <textarea
-                      className="form-control"
-                      id="missatge"
-                      name="missatge"
-                      rows="3"
-                      value={formFields.missatge}
-                      onChange={handleChange}
-                      required
-                    ></textarea>
-                  </div>
-                  <button type="submit" className="btn btn-primary">
-                    Enviar
-                  </button>
-                  {isFormSubmitted && (
-                    <p className="mt-3">¡Missatge enviat!</p>
-                  )}
-                </form>
+                <p>
+                  <strong>📧</strong> info@jctagency.com
+                </p>
+                <p>
+                  <strong>📍</strong> Tarragona (Catalunya)
+                </p>
+                <p>
+                  <strong>📱</strong> 633 391 411
+                </p>
               </div>
             </div>
           </div>

--- a/src/components/layouts/layout.js
+++ b/src/components/layouts/layout.js
@@ -6,20 +6,16 @@ const Layout = ({ children }) => (
   <>
     <Header />
     <main>{children}</main>
-    <footer className="pt-5 bg-dark text-white pb-3">
-      <div className="container d-flex align-items-center justify-content-between pb-3">
-        <div className="col-md-3 w-25">
-          <img className="navbar-logo w-50" src={logoImage} alt="Logo JCT Agency" />
+    <footer className="bg-primary text-white py-4">
+      <div className="container d-flex flex-column flex-md-row align-items-center justify-content-between">
+        <div className="mb-3 mb-md-0">
+          <img src={logoImage} alt="Logo JCT Agency" style={{ height: '40px' }} />
         </div>
-        <div className="col-md-3 w-25">
-          <h5>Contacto</h5>
-          <p>Dirección: Online</p>
-          <p>Email: joan@jctagency.com</p>
-          <p>Teléfono: 633 391 411</p>
+        <div className="text-center">
+          <p className="mb-1">© 2024 JCT Agency – Solucions digitals i software SaaS.</p>
+          <p className="mb-1">Email: joan@jctagency.com | Telèfon: 633 391 411</p>
+          <p className="mb-0">Segueix-nos a LinkedIn</p>
         </div>
-      </div>
-      <div className="text-center">
-        <p>© 2024 JCT Agency.</p>
       </div>
     </footer>
   </>


### PR DESCRIPTION
## Summary
- revamp hero and add client, services, product, benefits, values, blog and contact sections to the home page
- update site footer with new contact info and call to follow on LinkedIn

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac32e01d048323ab58ddfba39588af