### PR TITLE
Add blog section with SEO articles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,10 @@
 import './App.css';
-import {BrowserRouter, Route, Routes} from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Home from "./components/components/home";
 import Contact from "./components/components/contact";
+import Blog from "./components/components/blog";
+import SeoArticle from "./components/components/blog/seo";
+import SoftwareArticle from "./components/components/blog/software";
 
 function App() {
   return (
@@ -9,6 +12,9 @@ function App() {
         <Routes>
           <Route path='/' element={<Home/>}/>
           <Route path='/contacto' element={<Contact/>}/>
+          <Route path='/blog' element={<Blog/>}/>
+          <Route path='/blog/optimitzacio-seo' element={<SeoArticle/>}/>
+          <Route path='/blog/software-a-mida-beneficis' element={<SoftwareArticle/>}/>
         </Routes>
       </BrowserRouter>
   );

--- a/src/components/components/blog.js
+++ b/src/components/components/blog.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import Layout from '../layouts/layout';
+
+const Blog = () => (
+  <Layout>
+    <Helmet>
+      <title>Blog de JCT Agency | Recursos per a PIMEs i gestories</title>
+      <meta
+        name="description"
+        content="Articles sobre SEO, desenvolupament i màrqueting digital per ajudar la teva empresa a créixer."
+      />
+    </Helmet>
+    <section className="container py-5">
+      <h1 className="mb-4 text-center">Blog</h1>
+      <article className="mb-4">
+        <h2>
+          <Link to="/blog/optimitzacio-seo" className="text-decoration-none">
+            Optimització SEO per a PIMEs: 5 consells clau
+          </Link>
+        </h2>
+        <p className="text-muted">
+          Aprèn com millorar la visibilitat del teu negoci a Google amb tècniques senzilles i efectives.
+        </p>
+      </article>
+      <article className="mb-4">
+        <h2>
+          <Link to="/blog/software-a-mida-beneficis" className="text-decoration-none">
+            Beneficis del software a mida per a gestories i PIMEs
+          </Link>
+        </h2>
+        <p className="text-muted">
+          Descobreix per què invertir en solucions personalitzades pot impulsar l'eficiència del teu negoci.
+        </p>
+      </article>
+    </section>
+  </Layout>
+);
+
+export default Blog;

--- a/src/components/components/blog/seo.js
+++ b/src/components/components/blog/seo.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Layout from '../../layouts/layout';
+
+const SeoArticle = () => (
+  <Layout>
+    <Helmet>
+      <title>Optimització SEO per a PIMEs: 5 consells clau | JCT Agency</title>
+      <meta
+        name="description"
+        content="Guia pràctica de SEO per a petites empreses: millora el posicionament orgànic a Google amb passos simples."
+      />
+    </Helmet>
+    <article className="container py-5">
+      <h1 className="mb-4">Optimització SEO per a PIMEs: 5 consells clau</h1>
+      <p>
+        Posicionar la teva empresa als cercadors és essencial per atraure nous clients.
+        A continuació, et presentem cinc consells pràctics per començar a treballar el teu SEO:
+      </p>
+      <h2 className="mt-4">1. Investigació de paraules clau</h2>
+      <p>
+        Identifica els termes que els teus clients potencials busquen. Utilitza eines com
+        Google Keyword Planner per descobrir oportunitats amb poc volum de competència.
+      </p>
+      <h2 className="mt-4">2. Contingut de qualitat</h2>
+      <p>
+        Redacta articles que resolguin dubtes reals i utilitza les paraules clau de manera natural.
+        El contingut valuós augmenta el temps de permanència i redueix la taxa de rebot.
+      </p>
+      <h2 className="mt-4">3. Optimització tècnica</h2>
+      <p>
+        Assegura't que la teva web carregui ràpidament i sigui responsive. Una bona experiència d'usuari
+        és clau perquè Google valori positivament el teu lloc.
+      </p>
+      <h2 className="mt-4">4. Enllaços interns i externs</h2>
+      <p>
+        Crea una xarxa d'enllaços entre les teves pàgines i busca col·laboracions per obtenir backlinks
+        de qualitat. Això incrementa l'autoritat del teu domini.
+      </p>
+      <h2 className="mt-4">5. Seguiment i anàlisi</h2>
+      <p>
+        Monitoritza els resultats amb Google Analytics i Search Console. Ajusta la teva estratègia segons les dades.
+      </p>
+      <p className="mt-4">
+        Implementant aquests passos, la teva PIME millorarà la visibilitat en línia i atraurà clients potencials.
+      </p>
+    </article>
+  </Layout>
+);
+
+export default SeoArticle;

--- a/src/components/components/blog/software.js
+++ b/src/components/components/blog/software.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Layout from '../../layouts/layout';
+
+const SoftwareArticle = () => (
+  <Layout>
+    <Helmet>
+      <title>Beneficis del software a mida per a gestories i PIMEs | JCT Agency</title>
+      <meta
+        name="description"
+        content="Descobreix com el software personalitzat pot millorar l'eficiència i la competitivitat del teu negoci."
+      />
+    </Helmet>
+    <article className="container py-5">
+      <h1 className="mb-4">Beneficis del software a mida per a gestories i PIMEs</h1>
+      <p>
+        Les solucions genèriques sovint no cobreixen les necessitats específiques d'una empresa. El software a mida
+        permet adaptar les funcionalitats exactes al teu flux de treball.
+      </p>
+      <h2 className="mt-4">Eficiència operativa</h2>
+      <p>
+        Automatitzar tasques repetitives redueix errors i allibera temps per a activitats de més valor.
+      </p>
+      <h2 className="mt-4">Escalabilitat</h2>
+      <p>
+        A mesura que el teu negoci creix, el software es pot ampliar sense haver de començar de zero.
+      </p>
+      <h2 className="mt-4">Integració amb altres eines</h2>
+      <p>
+        Un desenvolupament personalitzat permet connectar sistemes ja existents, evitant duplicacions de dades.
+      </p>
+      <h2 className="mt-4">Avantatge competitiu</h2>
+      <p>
+        Oferir una experiència diferenciadora als teus clients et posiciona per davant de la competència.
+      </p>
+      <p className="mt-4">
+        En invertir en tecnologia a mida, gestories i PIMEs poden optimitzar processos i preparar-se per a un creixement sostenible.
+      </p>
+    </article>
+  </Layout>
+);
+
+export default SoftwareArticle;

--- a/src/components/components/header.js
+++ b/src/components/components/header.js
@@ -12,6 +12,7 @@ const Header = () => (
       <Navbar.Collapse id="main-navbar">
         <Nav className="ms-auto">
           <Nav.Link href="/">Home</Nav.Link>
+          <Nav.Link href="/blog">Blog</Nav.Link>
           <Nav.Link href="/contacto">Contacto</Nav.Link>
         </Nav>
       </Navbar.Collapse>


### PR DESCRIPTION
## Summary
- add blog page with navigation link
- include SEO-focused articles on optimization tips and custom software benefits
- configure router for blog and article routes

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ac33bdc97c8323bbbda235ebdad24d