### PR TITLE
Fix invalid anchor links in Avero footer

### DIFF
--- a/src/components/components/avero.js
+++ b/src/components/components/avero.js
@@ -139,9 +139,9 @@ const Avero = () => (
         <div className="container">
           <p><a href="https://avero.jctagency.com">avero.jctagency.com</a></p>
           <ul className="list-unstyled">
-            <li><a href="#">Programa de facturació VeriFactu</a></li>
-            <li><a href="#">Factures electròniques AEAT</a></li>
-            <li><a href="#">Software de facturació per autònoms i gestories</a></li>
+            <li><a href="/programa-de-facturacio-verifactu">Programa de facturació VeriFactu</a></li>
+            <li><a href="/factures-electroniques-aeat">Factures electròniques AEAT</a></li>
+            <li><a href="/software-facturacio-autonoms-gestories">Software de facturació per autònoms i gestories</a></li>
           </ul>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- replace placeholder `href="#"` values with descriptive URLs in Avero footer links

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac3810cf08832393a8b28c331a0c50