### PR TITLE
refactor: professionalize header and footer styling

### DIFF
--- a/src/components/components/avero.js
+++ b/src/components/components/avero.js
@@ -135,10 +135,10 @@ const Avero = () => (
       </section>
 
       {/* Peu de pàgina */}
-      <footer className="py-4 bg-light">
-        <div className="container">
-          <p><a href="https://avero.jctagency.com">avero.jctagency.com</a></p>
-          <ul className="list-unstyled">
+      <footer className="footer-sub py-4">
+        <div className="container text-center text-md-start">
+          <p className="mb-2"><a href="https://avero.jctagency.com">avero.jctagency.com</a></p>
+          <ul className="list-unstyled mb-0">
             <li><a href="/programa-de-facturacio-verifactu">Programa de facturació VeriFactu</a></li>
             <li><a href="/factures-electroniques-aeat">Factures electròniques AEAT</a></li>
             <li><a href="/software-facturacio-autonoms-gestories">Software de facturació per autònoms i gestories</a></li>

--- a/src/components/components/header.js
+++ b/src/components/components/header.js
@@ -3,10 +3,10 @@ import { Navbar, Nav, Container } from 'react-bootstrap';
 import logoImage from '../img/LOGO JCTAGENCY.png';
 
 const Header = () => (
-  <Navbar bg="primary" variant="dark" expand="lg" className="py-3">
+  <Navbar expand="lg" className="navbar-custom shadow-sm py-3" sticky="top">
     <Container>
       <Navbar.Brand href="/">
-        <img src={logoImage} alt="JCT Agency" style={{ height: '40px' }} />
+        <img src={logoImage} alt="JCT Agency" />
       </Navbar.Brand>
       <Navbar.Toggle aria-controls="main-navbar" />
       <Navbar.Collapse id="main-navbar">

--- a/src/components/layouts/layout.js
+++ b/src/components/layouts/layout.js
@@ -6,12 +6,12 @@ const Layout = ({ children }) => (
   <>
     <Header />
     <main>{children}</main>
-    <footer className="bg-primary text-white py-4">
+    <footer className="footer-custom py-4 mt-auto">
       <div className="container d-flex flex-column flex-md-row align-items-center justify-content-between">
         <div className="mb-3 mb-md-0">
           <img src={logoImage} alt="Logo JCT Agency" style={{ height: '40px' }} />
         </div>
-        <div className="text-center">
+        <div className="text-center text-md-end">
           <p className="mb-1">© 2024 JCT Agency – Solucions digitals i software SaaS.</p>
           <p className="mb-1">Email: joan@jctagency.com | Telèfon: 633 391 411</p>
           <p className="mb-0">Segueix-nos a LinkedIn</p>

--- a/src/index.css
+++ b/src/index.css
@@ -24,3 +24,54 @@ code {
   background-color: #0d6efd;
   color: white;
 }
+
+.navbar-custom {
+  background-color: #ffffff;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.navbar-custom .navbar-brand img {
+  height: 40px;
+}
+
+.navbar-custom .nav-link {
+  color: #0d1b2a;
+  font-weight: 500;
+  margin-left: 1rem;
+}
+
+.navbar-custom .nav-link:hover,
+.navbar-custom .nav-link:focus {
+  color: #0d6efd;
+}
+
+.footer-custom {
+  background-color: #0d1b2a;
+  color: #f8f9fa;
+}
+
+.footer-custom a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.footer-custom a:hover,
+.footer-custom a:focus {
+  text-decoration: underline;
+}
+
+.footer-sub {
+  background-color: #f8f9fa;
+  color: #6c757d;
+  border-top: 1px solid #e5e5e5;
+}
+
+.footer-sub a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.footer-sub a:hover,
+.footer-sub a:focus {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Restyle header with a clean sticky navbar and custom link colors
- Rebuild footer with darker palette and responsive alignment
- Add shared CSS utilities for professional header and footer appearance

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ac3c4a7144832389f3d84c4c682683