### PR TITLE
chore: personalize meta descriptions for SEO

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="JCT Agency, agència digital especialitzada en desenvolupament de software SaaS i solucions tecnològiques per a empreses."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>JCT Agency</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/components/avero.js
+++ b/src/components/components/avero.js
@@ -7,7 +7,10 @@ const Avero = () => (
   <Layout>
     <Helmet>
       <title>Avero – Programa de facturació 100% adaptat a VeriFactu i la Llei Crea y Crece</title>
-      <meta name="description" content="La solució més simple i moderna per complir amb VeriFactu i la Llei Crea y Crece." />
+      <meta
+        name="description"
+        content="Programa de facturació Avero per a autònoms, PIMEs i gestories; compleix Veri*Factu i la Llei Crea y Crece amb una eina senzilla i moderna."
+      />
     </Helmet>
     <div className="bg-white text-dark">
       {/* Hero */}

--- a/src/components/components/blog.js
+++ b/src/components/components/blog.js
@@ -9,7 +9,7 @@ const Blog = () => (
       <title>Blog de JCT Agency | Recursos per a PIMEs i gestories</title>
       <meta
         name="description"
-        content="Articles sobre SEO, desenvolupament i màrqueting digital per ajudar la teva empresa a créixer."
+        content="Guies de digitalització, SEO i programari Veri*Factu per fer créixer el teu negoci i millorar la gestió empresarial."
       />
     </Helmet>
     <section className="container py-5">

--- a/src/components/components/blog/digitalitzar-pime.js
+++ b/src/components/components/blog/digitalitzar-pime.js
@@ -8,7 +8,7 @@ const DigitalitzarPimeArticle = () => (
       <title>Com digitalitzar la gestió d’una PIME en 5 passos | JCT Agency</title>
       <meta
         name="description"
-        content="Guia completa per a petites empreses que volen digitalitzar-se: eines, estratègies i bones pràctiques."
+        content="Passos clau per digitalitzar una PIME amb eines SaaS, estratègies de transformació digital i consells pràctics per millorar l'eficiència."
       />
     </Helmet>
     <article className="container py-5">

--- a/src/components/components/blog/saas-vs-tradicional.js
+++ b/src/components/components/blog/saas-vs-tradicional.js
@@ -8,7 +8,7 @@ const SaasVsTradicionalArticle = () => (
       <title>Per què un SaaS és millor que un software tradicional? | JCT Agency</title>
       <meta
         name="description"
-        content="Comparativa completa entre solucions SaaS i software tradicional: costos, flexibilitat i seguretat."
+        content="Comparativa entre SaaS i software tradicional per escollir la millor opció en costos, escalabilitat i seguretat per al teu negoci."
       />
     </Helmet>
     <article className="container py-5">

--- a/src/components/components/blog/seo.js
+++ b/src/components/components/blog/seo.js
@@ -8,7 +8,7 @@ const SeoArticle = () => (
       <title>Optimització SEO per a PIMEs: guia completa | JCT Agency</title>
       <meta
         name="description"
-        content="Article extens sobre SEO per a petites empreses: estratègies, eines i bones pràctiques per millorar el posicionament a Google."
+        content="Guia SEO per a PIMEs amb tècniques per posicionar la web a Google, atraure clients locals i optimitzar continguts."
       />
     </Helmet>
     <article className="container py-5">

--- a/src/components/components/blog/software.js
+++ b/src/components/components/blog/software.js
@@ -8,7 +8,7 @@ const SoftwareArticle = () => (
       <title>Beneficis del software a mida per a gestories i PIMEs | JCT Agency</title>
       <meta
         name="description"
-        content="Anàlisi detallada sobre el valor del software personalitzat per a petites empreses i gestories: eficiència, integració i creixement."
+        content="Beneficis del software a mida per a gestories i PIMEs: automatitza processos, integra eines i impulsa el creixement empresarial."
       />
     </Helmet>
     <article className="container py-5">

--- a/src/components/components/blog/verifactu-gestories.js
+++ b/src/components/components/blog/verifactu-gestories.js
@@ -8,7 +8,7 @@ const VerifactuGestoriesArticle = () => (
       <title>Guia pràctica per a gestories sobre Veri*Factu | JCT Agency</title>
       <meta
         name="description"
-        content="Tot el que una gestoria ha de saber per adaptar-se a Veri*Factu: normativa, passos d’implementació i consells."
+        content="Guia per a gestories sobre Veri*Factu: requisits de l'AEAT, passos d'implantació i recomanacions per garantir el compliment legal."
       />
     </Helmet>
     <article className="container py-5">

--- a/src/components/components/contact.js
+++ b/src/components/components/contact.js
@@ -49,7 +49,10 @@ const Contact = () => {
             <Helmet>
                 <title>JCT Agency - Contacto</title>
                 <link rel="canonical" href="https://jctagency.com/contacto"/>
-                <meta name="description" content="Estamos disponibles para resolver tus dudas y ofrecerte la mejor solución."/>
+                <meta
+                    name="description"
+                    content="Contacta amb JCT Agency per rebre assessorament tecnològic i solucions digitals adaptades al teu negoci."
+                />
             </Helmet>
 
             <div>

--- a/src/components/components/home.js
+++ b/src/components/components/home.js
@@ -51,7 +51,7 @@ const Home = () => {
         <title>JCT Agency | Solucions digitals per fer créixer el teu negoci</title>
         <meta
           name="description"
-          content="Som una agència tecnològica especialitzada en software SaaS i programari empresarial."
+          content="Agència digital catalana especialista en software SaaS i solucions tecnològiques per a autònoms, PIMEs i gestories."
         />
       </Helmet>
 


### PR DESCRIPTION
## Summary
- add tailored meta description to HTML template
- personalize meta descriptions on home, contact, blog and article pages

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ac4d50d6d08323ad5bda27734b0fe2