### PR TITLE
Enhance home spacing and CTA, unify Avero colors

### DIFF
--- a/src/components/components/avero.js
+++ b/src/components/components/avero.js
@@ -21,13 +21,13 @@ const Avero = () => (
               <h1>Avero – Programa de facturació 100% adaptat a VeriFactu i la Llei Crea y Crece.*</h1>
               <p>La solució més simple i moderna per a autònoms, PIMEs i gestories. Compleix amb la normativa sense complicacions.</p>
               <div className="d-flex gap-3 mt-3 flex-column flex-sm-row">
-                <a href="https://avero.jctagency.com" className="btn btn-primary">Prova Avero gratis</a>
-                <a href="/contacto" className="btn btn-outline-primary">Demana una demo</a>
+                <a href="https://avero.jctagency.com" className="btn btn-avero">Prova Avero gratis</a>
+                <a href="/contacto" className="btn btn-outline-avero">Demana una demo</a>
               </div>
             </div>
             <div className="col-md-6 text-center position-relative">
               <img src={AveroLogo} alt="Mockup Avero" className="img-fluid" style={{ maxWidth: '400px' }} />
-              <span className="badge bg-success position-absolute top-0 start-50 translate-middle-x mt-2">Adaptat a Veri*Factu – RD 1007/2023</span>
+              <span className="badge bg-avero position-absolute top-0 start-50 translate-middle-x mt-2">Adaptat a Veri*Factu – RD 1007/2023</span>
             </div>
           </div>
         </div>
@@ -122,7 +122,7 @@ const Avero = () => (
               </tr>
             </tbody>
           </table>
-          <a href="https://avero.jctagency.com" className="btn btn-primary">Consulta els nostres plans</a>
+          <a href="https://avero.jctagency.com" className="btn btn-avero">Consulta els nostres plans</a>
         </div>
       </section>
 

--- a/src/components/components/home.js
+++ b/src/components/components/home.js
@@ -20,6 +20,7 @@ import confiancaImg from "../img/CONFIANÇA.png";
 import eficienciaImg from "../img/EFICIENCIA.png";
 import escalabilitatImg from "../img/ESCALABILITAT.png";
 import aliancesImg from "../img/ALIANÇES.png";
+import portatilIcon from "../img/portatilIcon.png";
 
 const Home = () => {
   const [isFormSubmitted, setFormSubmitted] = useState(false);
@@ -55,7 +56,7 @@ const Home = () => {
         />
       </Helmet>
 
-      <div className="bg-white text-dark">
+      <div className="bg-white text-dark home-view">
         {/* Hero */}
         <section className="py-5">
           <div className="container">
@@ -116,6 +117,22 @@ const Home = () => {
                 />
                 <h5>Gestories</h5>
                 <p>Programari que facilita nous serveis digitals als clients.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA custom software */}
+        <section id="cta-programari" className="text-center bg-light">
+          <div className="container">
+            <div className="row align-items-center g-4">
+              <div className="col-md-6">
+                <h2 className="mb-3">Necessites un programa específic per la teva empresa?</h2>
+                <p>Vols estalviar temps optimitzant tasques amb un programari a mida!</p>
+                <a href="#contacte" className="btn btn-primary mt-3">Contacta'ns</a>
+              </div>
+              <div className="col-md-6 text-center">
+                <img src={portatilIcon} alt="Programari a mida" className="img-fluid" style={{ maxWidth: "300px" }} />
               </div>
             </div>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -75,3 +75,59 @@ code {
 .footer-sub a:focus {
   text-decoration: underline;
 }
+
+/* Avero button styles */
+.btn-avero {
+  background-color: #ff6600;
+  border-color: #ff6600;
+  color: #fff;
+}
+
+.btn-avero:hover,
+.btn-avero:focus {
+  background-color: #e65c00;
+  border-color: #e65c00;
+  color: #fff;
+}
+
+.btn-outline-avero {
+  color: #ff6600;
+  border-color: #ff6600;
+}
+
+.btn-outline-avero:hover,
+.btn-outline-avero:focus {
+  background-color: #ff6600;
+  color: #fff;
+}
+
+/* Home page layout improvements */
+.home-view section {
+  padding-top: 5rem;
+  padding-bottom: 5rem;
+}
+
+.home-view section + section {
+  margin-top: 3rem;
+}
+
+.home-view a:not(.btn) {
+  color: #0d6efd;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.home-view a:not(.btn):hover,
+.home-view a:not(.btn):focus {
+  text-decoration: underline;
+}
+
+.home-view .btn-link {
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.home-view .btn-link:hover,
+.home-view .btn-link:focus {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- increase spacing on home sections and style links
- add custom software CTA with image
- switch Avero buttons and badge to orange brand palette

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad5f9afde483238584bfa7d00491de