### PR TITLE
feat: add budget calculator page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import SoftwareArticle from "./components/components/blog/software";
 import DigitalitzarPimeArticle from "./components/components/blog/digitalitzar-pime";
 import VerifactuGestoriesArticle from "./components/components/blog/verifactu-gestories";
 import SaasVsTradicionalArticle from "./components/components/blog/saas-vs-tradicional";
+import Pressupost from "./components/components/pressupost";
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
           <Route path='/blog/digitalitzar-pime' element={<DigitalitzarPimeArticle/>}/>
           <Route path='/blog/verifactu-gestories' element={<VerifactuGestoriesArticle/>}/>
           <Route path='/blog/saas-vs-tradicional' element={<SaasVsTradicionalArticle/>}/>
+          <Route path='/pressupost' element={<Pressupost/>}/>
         </Routes>
       </BrowserRouter>
   );

--- a/src/components/components/header.js
+++ b/src/components/components/header.js
@@ -14,6 +14,7 @@ const Header = () => (
           <Nav.Link href="/">Home</Nav.Link>
           <Nav.Link href="/avero">Avero</Nav.Link>
           <Nav.Link href="/blog">Blog</Nav.Link>
+          <Nav.Link href="/pressupost">Pressupost</Nav.Link>
           <Nav.Link href="/contacto">Contacto</Nav.Link>
         </Nav>
       </Navbar.Collapse>

--- a/src/components/components/home.js
+++ b/src/components/components/home.js
@@ -327,6 +327,15 @@ const Home = () => {
           </div>
         </section>
 
+        {/* Pressupost */}
+        <section id="pressupost" className="py-5 bg-light">
+          <div className="container text-center">
+            <h2 className="mb-4">Vols una estimació del teu projecte?</h2>
+            <p>Utilitza la nostra calculadora per conèixer el pressupost aproximat.</p>
+            <a href="/pressupost" className="btn btn-outline-primary">Calcula el teu pressupost</a>
+          </div>
+        </section>
+
         {/* Contacte */}
         <section id="contacte" className="py-5 bg-light">
           <div className="container">

--- a/src/components/components/pressupost.js
+++ b/src/components/components/pressupost.js
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import Layout from '../layouts/layout';
+import { Helmet } from 'react-helmet';
+import emailjs from 'emailjs-com';
+
+const Pressupost = () => {
+  const [service, setService] = useState('');
+  const initialForm = {
+    nombre: '',
+    empresa: '',
+    email: '',
+    pages: '1-5',
+    ecommerce: false,
+    modules: '1-2',
+    cloud: false,
+    platforms: 'one',
+    auth: false
+  };
+  const [formData, setFormData] = useState(initialForm);
+  const [price, setPrice] = useState(null);
+  const [sent, setSent] = useState(false);
+
+  const handleServiceChange = (e) => {
+    setService(e.target.value);
+    setPrice(null);
+    setSent(false);
+  };
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData({ ...formData, [name]: type === 'checkbox' ? checked : value });
+  };
+
+  const calculatePrice = () => {
+    let total = 0;
+    if (service === 'web') {
+      total = 1300;
+      if (formData.pages === '6-10') total += 500;
+      if (formData.pages === '11+') total += 1000;
+      if (formData.ecommerce) total += 1000;
+    } else if (service === 'software') {
+      total = 4500;
+      if (formData.modules === '3-5') total += 2000;
+      if (formData.modules === '6+') total += 4000;
+      if (formData.cloud) total += 1500;
+    } else if (service === 'app') {
+      total = 7500;
+      if (formData.platforms === 'both') total += 2500;
+      if (formData.auth) total += 1000;
+    }
+    return total;
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const estimated = calculatePrice();
+    setPrice(estimated);
+    const { nombre, empresa, email, ...rest } = formData;
+    const mensaje = `Servei: ${service}\nDetalls: ${JSON.stringify(rest)}\nPressupost: ${estimated}€`;
+    emailjs
+      .send('service_uaggcy8', 'template_yav8r89', {
+        nombre,
+        empresa,
+        email,
+        mensaje
+      }, 'PrtHsOGCYBrChfJU3')
+      .then(() => {
+        setSent(true);
+        setFormData(initialForm);
+      })
+      .catch(() => setSent(false));
+  };
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>Calcula el teu pressupost | JCT Agency</title>
+        <meta name="description" content="Calcula de manera orientativa el cost del teu projecte digital." />
+      </Helmet>
+      <div className="container py-5">
+        <h1 className="mb-4 text-center">Calculadora de pressupost</h1>
+        <div className="mb-4">
+          <label className="form-label">Tipus de projecte</label>
+          <select className="form-select" value={service} onChange={handleServiceChange} required>
+            <option value="">Selecciona una opció</option>
+            <option value="web">Pàgina web</option>
+            <option value="software">Programa a mida</option>
+            <option value="app">App mòbil</option>
+          </select>
+        </div>
+
+        {service && (
+          <form onSubmit={handleSubmit}>
+            {service === 'web' && (
+              <>
+                <div className="mb-3">
+                  <label className="form-label">Nombre de pàgines</label>
+                  <select name="pages" className="form-select" value={formData.pages} onChange={handleChange}>
+                    <option value="1-5">1-5</option>
+                    <option value="6-10">6-10</option>
+                    <option value="11+">Més de 10</option>
+                  </select>
+                </div>
+                <div className="form-check mb-3">
+                  <input className="form-check-input" type="checkbox" id="ecommerce" name="ecommerce" checked={formData.ecommerce} onChange={handleChange} />
+                  <label className="form-check-label" htmlFor="ecommerce">Incloure e-commerce</label>
+                </div>
+              </>
+            )}
+
+            {service === 'software' && (
+              <>
+                <div className="mb-3">
+                  <label className="form-label">Nombre de mòduls</label>
+                  <select name="modules" className="form-select" value={formData.modules} onChange={handleChange}>
+                    <option value="1-2">1-2</option>
+                    <option value="3-5">3-5</option>
+                    <option value="6+">6 o més</option>
+                  </select>
+                </div>
+                <div className="form-check mb-3">
+                  <input className="form-check-input" type="checkbox" id="cloud" name="cloud" checked={formData.cloud} onChange={handleChange} />
+                  <label className="form-check-label" htmlFor="cloud">Integració al núvol</label>
+                </div>
+              </>
+            )}
+
+            {service === 'app' && (
+              <>
+                <div className="mb-3">
+                  <label className="form-label">Plataformes</label>
+                  <select name="platforms" className="form-select" value={formData.platforms} onChange={handleChange}>
+                    <option value="one">iOS o Android</option>
+                    <option value="both">iOS i Android</option>
+                  </select>
+                </div>
+                <div className="form-check mb-3">
+                  <input className="form-check-input" type="checkbox" id="auth" name="auth" checked={formData.auth} onChange={handleChange} />
+                  <label className="form-check-label" htmlFor="auth">Autenticació d'usuaris</label>
+                </div>
+              </>
+            )}
+
+            <div className="mb-3">
+              <label className="form-label">Nom</label>
+              <input type="text" name="nombre" className="form-control" value={formData.nombre} onChange={handleChange} required />
+            </div>
+            <div className="mb-3">
+              <label className="form-label">Empresa</label>
+              <input type="text" name="empresa" className="form-control" value={formData.empresa} onChange={handleChange} />
+            </div>
+            <div className="mb-3">
+              <label className="form-label">Email</label>
+              <input type="email" name="email" className="form-control" value={formData.email} onChange={handleChange} required />
+            </div>
+            <button type="submit" className="btn btn-primary">Calcula pressupost</button>
+            {sent && <p className="mt-3">Dades enviades correctament.</p>}
+          </form>
+        )}
+
+        {price !== null && (
+          <div className="alert alert-info mt-4" role="alert">
+            Pressupost estimat: {price}€
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+};
+
+export default Pressupost;
+


### PR DESCRIPTION
## Summary
- add pressupost calculator component with dynamic pricing and email integration
- link budget calculator from navigation and home
- register new /pressupost route

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aed75c33788323930c181bc65261ba