### PR TITLE
Switch to EmailJS browser SDK for email forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "web-jct-agency",
       "version": "0.1.0",
       "dependencies": {
+        "@emailjs/browser": "^3.12.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "bootstrap": "^5.3.2",
-        "emailjs-com": "^3.2.0",
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.2",
         "react-dom": "^18.2.0",
@@ -2311,6 +2311,15 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-3.12.1.tgz",
+      "integrity": "sha512-C5nK07CgSCFx3onsuRt/ZaaMvIi0T3SHHanM7fKozjSvbZu+OjHHP9W608fYpic0OavF7yIlfy4+lRDO33JdbA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -7321,15 +7330,6 @@
       "version": "1.4.620",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.620.tgz",
       "integrity": "sha512-a2fcSHOHrqBJsPNXtf6ZCEZpXrFCcbK1FBxfX3txoqWzNgtEDG1f3M59M98iwxhRW4iMKESnSjbJ310/rkrp0g=="
-    },
-    "node_modules/emailjs-com": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/emailjs-com/-/emailjs-com-3.2.0.tgz",
-      "integrity": "sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA==",
-      "deprecated": "The SDK name changed to @emailjs/browser",
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emailjs/browser": "^3.12.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "bootstrap": "^5.3.2",
-    "emailjs-com": "^3.2.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.2",
     "react-dom": "^18.2.0",

--- a/src/components/components/contact.js
+++ b/src/components/components/contact.js
@@ -1,5 +1,5 @@
 import Layout from "../layouts/layout";
-import emailjs from 'emailjs-com';
+import emailjs from '@emailjs/browser';
 import React, {useState} from "react";
 import {Helmet} from "react-helmet";
 

--- a/src/components/components/home.js
+++ b/src/components/components/home.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Layout from "../layouts/layout";
 import { Helmet } from "react-helmet";
-import emailjs from "emailjs-com";
+import emailjs from "@emailjs/browser";
 
 import heroImg from "../img/QUI SOM.png";
 import autonomIcon from "../img/AUTONOM.png";

--- a/src/components/components/pressupost.js
+++ b/src/components/components/pressupost.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Layout from '../layouts/layout';
 import { Helmet } from 'react-helmet';
-import emailjs from 'emailjs-com';
+import emailjs from '@emailjs/browser';
 import { Link } from 'react-router-dom';
 
 const Pressupost = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,9 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import emailjs from '@emailjs/browser';
+
+emailjs.init('PrtHsOGCYBrChfJU3');
 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));


### PR DESCRIPTION
## Summary
- Replace deprecated `emailjs-com` with `@emailjs/browser`
- Initialize EmailJS public key globally
- Update contact, home, and budget forms to use new SDK

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68aedb34422c8323aec1c54074932ac1