### PR TITLE
Increase AOS transition duration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ function App() {
   useEffect(() => {
     AOS.init({
       once: true,
-      duration: 800,
+      duration: 1000,
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- adjust AOS configuration to use a 1000ms animation duration

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68af4289dc888323b500d3a58e52d951