### PR TITLE
Make header and footer logos circular

### DIFF
--- a/src/components/components/header.js
+++ b/src/components/components/header.js
@@ -6,7 +6,7 @@ const Header = () => (
   <Navbar expand="lg" className="navbar-custom shadow-sm py-3" sticky="top">
     <Container>
       <Navbar.Brand href="/">
-        <img src={logoImage} alt="JCT Agency" />
+        <img src={logoImage} alt="JCT Agency" className="rounded-circle" />
       </Navbar.Brand>
       <Navbar.Toggle aria-controls="main-navbar" />
       <Navbar.Collapse id="main-navbar">

--- a/src/components/layouts/layout.js
+++ b/src/components/layouts/layout.js
@@ -9,7 +9,7 @@ const Layout = ({ children }) => (
     <footer className="footer-custom py-4 mt-auto">
       <div className="container d-flex flex-column flex-md-row align-items-center justify-content-between">
         <div className="mb-3 mb-md-0">
-          <img src={logoImage} alt="Logo JCT Agency" />
+          <img src={logoImage} alt="Logo JCT Agency" className="rounded-circle" />
         </div>
         <div className="text-center text-md-end">
           <p className="mb-1">© 2024 JCT Agency – Solucions digitals i software SaaS.</p>


### PR DESCRIPTION
## Summary
- make header logo circular using Bootstrap class
- make footer logo circular to match header styling

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68affa2efed08323bf2c07910e61c109