### PR TITLE
Remove global meta description for per-page SEO

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,6 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="JCT Agency, agència digital especialitzada en desenvolupament de software SaaS i solucions tecnològiques per a empreses."
-    />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
## Summary
- drop default description from `index.html` so pages define their own meta descriptions

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b57bbdf11483239542ba8ca2f75eaa