### PR TITLE
Add results page with KPI placeholders and CTA

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import DigitalitzarPimeArticle from "./components/components/blog/digitalitzar-p
 import VerifactuGestoriesArticle from "./components/components/blog/verifactu-gestories";
 import SaasVsTradicionalArticle from "./components/components/blog/saas-vs-tradicional";
 import Pressupost from "./components/components/pressupost";
+import ResultsPage from "./pages/results/ResultsPage";
 
 function App() {
   useEffect(() => {
@@ -37,6 +38,7 @@ function App() {
         <Route path='/blog/verifactu-gestories' element={<VerifactuGestoriesArticle/>}/>
         <Route path='/blog/saas-vs-tradicional' element={<SaasVsTradicionalArticle/>}/>
         <Route path='/pressupost' element={<Pressupost/>}/>
+        <Route path='/resultats' element={<ResultsPage/>}/>
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/results/ResultsPage.css
+++ b/src/pages/results/ResultsPage.css
@@ -1,0 +1,262 @@
+.results-page {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  padding: 4rem 1.5rem 6rem;
+  color: #1f2933;
+  background: #f8fafc;
+}
+
+.results-hero {
+  background: linear-gradient(135deg, rgba(13, 110, 253, 0.12), rgba(67, 56, 202, 0.12));
+  border-radius: 24px;
+  padding: 3.5rem 3rem;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.results-hero__content {
+  max-width: 720px;
+}
+
+.eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #475569;
+  margin-bottom: 0.5rem;
+}
+
+.results-hero h1 {
+  font-size: 2.5rem;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 1.5rem;
+  color: #334155;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #2563eb;
+  color: #ffffff;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.3s ease;
+}
+
+.cta:hover {
+  background: #1d4ed8;
+}
+
+.kpi-section,
+.examples-section,
+.future-proof-section {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 3rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+}
+
+.kpi-section h2,
+.examples-section h2,
+.future-proof-section h2 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.section-intro {
+  color: #475569;
+  margin-bottom: 2rem;
+  max-width: 620px;
+  line-height: 1.6;
+}
+
+.kpi-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.kpi-card {
+  background: linear-gradient(135deg, #eff6ff, #eef2ff);
+  border-radius: 18px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.kpi-card h3 {
+  font-size: 1.1rem;
+  margin: 0;
+  color: #1e293b;
+}
+
+.kpi-impact {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.kpi-description {
+  color: #475569;
+  line-height: 1.5;
+}
+
+.examples-header {
+  margin-bottom: 2.5rem;
+  color: #475569;
+}
+
+.examples-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.example-card {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 20px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: #f9fafb;
+}
+
+.example-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.example-card__header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #0f172a;
+}
+
+.example-card__tag {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.example-diagram {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.diagram-column h4 {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #1d4ed8;
+  margin-bottom: 0.75rem;
+}
+
+.diagram-column ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.diagram-column li {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.06);
+  color: #334155;
+}
+
+.diagram-arrow {
+  font-size: 2rem;
+  color: #94a3b8;
+  align-self: center;
+}
+
+.placeholder-note {
+  font-size: 0.9rem;
+  color: #475569;
+  font-style: italic;
+}
+
+.example-cta {
+  align-self: flex-start;
+  text-decoration: none;
+  font-weight: 600;
+  color: #1d4ed8;
+  border-bottom: 1px solid rgba(37, 99, 235, 0.3);
+  padding-bottom: 0.2rem;
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.example-cta:hover {
+  color: #1e3a8a;
+  border-color: rgba(30, 58, 138, 0.6);
+}
+
+.future-proof-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.future-proof-slot {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(129, 140, 248, 0.12));
+  border-radius: 18px;
+  padding: 1.5rem;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 0.75rem;
+}
+
+.future-proof-slot h3 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.future-proof-slot p {
+  color: #475569;
+  line-height: 1.5;
+}
+
+@media (max-width: 768px) {
+  .results-hero {
+    padding: 2.5rem 2rem;
+  }
+
+  .results-hero h1 {
+    font-size: 2rem;
+  }
+
+  .examples-section,
+  .kpi-section,
+  .future-proof-section {
+    padding: 2.5rem 1.75rem;
+  }
+}

--- a/src/pages/results/ResultsPage.jsx
+++ b/src/pages/results/ResultsPage.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import './ResultsPage.css';
+
+const kpiHighlights = [
+  {
+    label: 'Temps d\'equip estalviat',
+    expectedImpact: '−5 – −10 h/setmana',
+    description: 'Placeholder per ajustar hores reals segons projecte i mida de l\'equip.'
+  },
+  {
+    label: 'Reducció d\'errors operatius',
+    expectedImpact: '−30% – −45%',
+    description: 'Placeholder per xifres d\'error actualitzades a cada implantació.'
+  },
+  {
+    label: 'Acceleració en el time-to-market',
+    expectedImpact: '−2 – −4 setmanes',
+    description: 'Placeholder per objectius reals de lliurament i cicles de llançament.'
+  },
+  {
+    label: 'Increment de satisfacció del client final',
+    expectedImpact: '+12 – +18 punts NPS',
+    description: 'Placeholder per dades d\'enquestes i feedbacks específics.'
+  }
+];
+
+const typicalExamples = [
+  {
+    title: 'Exemple típic: Integració d\'ERP',
+    before: ['Flux d\'informació dispers', 'Duplicació manual de dades', 'Visibilitat mensual tardana'],
+    after: ['Quadres de comandament en temps real', 'Sync automàtica entre sistemes', 'Decisions setmanals basades en dades'],
+    placeholderNote: 'Reservat per substituir per cas real d\'integració (quote + mètriques)'
+  },
+  {
+    title: 'Exemple típic: Portal de clients B2B',
+    before: ['Processos de comanda via email', 'Sense historial compartit', 'Alta càrrega del servei d\'atenció'],
+    after: ['Autoservei 24/7', 'Tracking centralitzat', 'Equip d\'atenció focalitzat en consultes de valor'],
+    placeholderNote: 'Reservat per testimoni real d\'empresa distribuïdora (en preparació)'
+  },
+  {
+    title: 'Exemple típic: Automatització de reporting',
+    before: ['Consola de fulls de càlcul', 'Errors humans recurrents', 'Tancaments mensuals lents'],
+    after: ['Pipeline validat i auditable', 'Alarmes automàtiques', 'Tancaments setmanals'],
+    placeholderNote: 'Espai per cita d\'equip financer i gràfic de resultats'
+  }
+];
+
+const ResultsPage = () => {
+  return (
+    <div className="results-page">
+      <header className="results-hero">
+        <div className="results-hero__content">
+          <p className="eyebrow">Resultats previstos</p>
+          <h1>Impacte tangible des del primer trimestre</h1>
+          <p className="subtitle">
+            Aquesta secció presenta KPI esperats i escenaris basats en projectes similars. Les xifres són placeholders
+            i es podran ajustar amb dades reals a partir de l\'anàlisi inicial i la monitorització continuada.
+          </p>
+          <a className="cta" href="/pressupost">Sol·licita una anàlisi personalitzada</a>
+        </div>
+      </header>
+
+      <section className="kpi-section">
+        <h2>KPI esperats (placeholders)</h2>
+        <p className="section-intro">
+          Cada projecte defineix objectius específics. Utilitza aquestes mètriques com a marc inicial fins que disposem
+          de dades contrastades del teu cas.
+        </p>
+        <div className="kpi-grid">
+          {kpiHighlights.map((kpi) => (
+            <article key={kpi.label} className="kpi-card">
+              <h3>{kpi.label}</h3>
+              <p className="kpi-impact">{kpi.expectedImpact}</p>
+              <p className="kpi-description">{kpi.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="examples-section" aria-labelledby="typical-examples-title">
+        <div className="examples-header">
+          <h2 id="typical-examples-title">Exemples típics (per convertir en casos reals)</h2>
+          <p>
+            Cada exemple inclou diagrama abans/després i una nota clara sobre el futur testimoni. Quan disposem de dades
+            concretes, només caldrà substituir els placeholders per mètriques, cites i logos.
+          </p>
+        </div>
+        <div className="examples-grid">
+          {typicalExamples.map((example) => (
+            <article key={example.title} className="example-card">
+              <header className="example-card__header">
+                <h3>{example.title}</h3>
+                <span className="example-card__tag">Exemple típic</span>
+              </header>
+              <div className="example-diagram">
+                <div className="diagram-column">
+                  <h4>Abans</h4>
+                  <ul>
+                    {example.before.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="diagram-arrow" aria-hidden="true">→</div>
+                <div className="diagram-column">
+                  <h4>Després</h4>
+                  <ul>
+                    {example.after.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+              <p className="placeholder-note">{example.placeholderNote}</p>
+              <a className="example-cta" href="/pressupost">Revisa l\'anàlisi pas a pas</a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="future-proof-section">
+        <h2>Properament: testimonis i cites reals</h2>
+        <div className="future-proof-grid">
+          <div className="future-proof-slot" role="status" aria-live="polite">
+            <h3>Slot per testimoni</h3>
+            <p>
+              Placeholder per a cita destacada d\'un client real, amb foto i càrrec. El disseny garanteix que afegir el
+              contingut no alteri l\'estructura actual.
+            </p>
+          </div>
+          <div className="future-proof-slot">
+            <h3>Slot per mètriques en profunditat</h3>
+            <p>
+              Espai reservat per a gràfiques o dashboards interactius un cop disposem d\'analítica consolidada.
+            </p>
+          </div>
+          <div className="future-proof-slot">
+            <h3>Slot per logotips i quotes</h3>
+            <p>
+              Àrea pensada per incorporar logotips aprovats i quotes verificades sense afectar l\'experiència existent.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ResultsPage;


### PR DESCRIPTION
## Summary
- create a results page with KPI placeholders, typical example diagrams, and CTAs toward deeper analysis
- add dedicated styling to present KPI cards, before/after diagrams, and future testimonial slots
- register the new results page route within the application router

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df89b14abc8323911e529e84056d14