### PR TITLE
feat: add multilingual routing and translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "@testing-library/user-event": "^13.5.0",
         "aos": "^2.3.4",
         "bootstrap": "^5.3.2",
+        "i18next": "^25.5.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.2",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
+        "react-i18next": "^16.0.0",
         "react-router-dom": "^6.21.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -1983,12 +1985,10 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.7.tgz",
-      "integrity": "sha512-w06OXVOFso7LcbzMiDGt+3X7Rh7Ho8MmgPoWU3rarH+8upf+wSU/grlGbWzQyr3DkdN6ZeuMFjpdwW0Q+HxobA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3786,104 +3786,6 @@
       "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@testing-library/dom": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "peer": true,
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -9335,6 +9237,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-webpack-plugin": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
@@ -9476,6 +9387,37 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.5.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.5.3.tgz",
+      "integrity": "sha512-joFqorDeQ6YpIXni944upwnuHBf5IoPMuqAchGVeQLdWC2JOjxgM9V8UGLhNIIH/Q8QleRxIi0BSRQehSrDLcg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -15155,6 +15097,32 @@
         "react": ">=16.3.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.0.0.tgz",
+      "integrity": "sha512-JQ+dFfLnFSKJQt7W01lJHWRC0SX7eDPobI+MSTJ3/gP39xH2g33AuTE7iddAfXYHamJdAeMGM0VFboPaD3G68Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.5.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -15387,11 +15355,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -17267,19 +17230,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -17505,6 +17455,15 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "@testing-library/user-event": "^13.5.0",
     "aos": "^2.3.4",
     "bootstrap": "^5.3.2",
+    "i18next": "^25.5.3",
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.2",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
+    "react-i18next": "^16.0.0",
     "react-router-dom": "^6.21.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import './App.css';
 import { useEffect } from 'react';
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes, Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import AOS from 'aos';
 import 'aos/dist/aos.css';
 
@@ -15,6 +16,68 @@ import DigitalitzarPimeArticle from "./components/components/blog/digitalitzar-p
 import VerifactuGestoriesArticle from "./components/components/blog/verifactu-gestories";
 import SaasVsTradicionalArticle from "./components/components/blog/saas-vs-tradicional";
 import Pressupost from "./components/components/pressupost";
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from "./i18n";
+
+const RedirectToPreferredLanguage = () => {
+  const location = useLocation();
+  let storedLanguage = DEFAULT_LANGUAGE;
+  if (typeof window !== 'undefined') {
+    const fromStorage = window.localStorage.getItem('preferredLanguage');
+    if (fromStorage && SUPPORTED_LANGUAGES.includes(fromStorage)) {
+      storedLanguage = fromStorage;
+    }
+  }
+
+  const targetPath = `/${storedLanguage}${location.pathname === '/' ? '' : location.pathname}${location.search}${location.hash}`;
+  return <Navigate to={targetPath} replace />;
+};
+
+const LocalizedRoutes = () => {
+  const { lang } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    if (!lang || !SUPPORTED_LANGUAGES.includes(lang)) {
+      let targetLanguage = DEFAULT_LANGUAGE;
+      if (typeof window !== 'undefined') {
+        const stored = window.localStorage.getItem('preferredLanguage');
+        if (stored && SUPPORTED_LANGUAGES.includes(stored)) {
+          targetLanguage = stored;
+        }
+      }
+
+      const suffix = location.pathname.split('/').slice(2).join('/');
+      const redirectPath = `/${targetLanguage}${suffix ? `/${suffix}` : ''}${location.search}${location.hash}`;
+      navigate(redirectPath, { replace: true });
+      return;
+    }
+
+    if (i18n.language !== lang) {
+      i18n.changeLanguage(lang);
+    }
+
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = lang;
+    }
+  }, [lang, i18n, navigate, location]);
+
+  return (
+    <Routes>
+      <Route index element={<Home />} />
+      <Route path='avero' element={<Avero />} />
+      <Route path='contacto' element={<Contact />} />
+      <Route path='blog' element={<Blog />} />
+      <Route path='blog/optimitzacio-seo' element={<SeoArticle />} />
+      <Route path='blog/software-a-mida-beneficis' element={<SoftwareArticle />} />
+      <Route path='blog/digitalitzar-pime' element={<DigitalitzarPimeArticle />} />
+      <Route path='blog/verifactu-gestories' element={<VerifactuGestoriesArticle />} />
+      <Route path='blog/saas-vs-tradicional' element={<SaasVsTradicionalArticle />} />
+      <Route path='pressupost' element={<Pressupost />} />
+    </Routes>
+  );
+};
 
 function App() {
   useEffect(() => {
@@ -27,16 +90,8 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path='/' element={<Home/>}/>
-        <Route path='/avero' element={<Avero/>}/>
-        <Route path='/contacto' element={<Contact/>}/>
-        <Route path='/blog' element={<Blog/>}/>
-        <Route path='/blog/optimitzacio-seo' element={<SeoArticle/>}/>
-        <Route path='/blog/software-a-mida-beneficis' element={<SoftwareArticle/>}/>
-        <Route path='/blog/digitalitzar-pime' element={<DigitalitzarPimeArticle/>}/>
-        <Route path='/blog/verifactu-gestories' element={<VerifactuGestoriesArticle/>}/>
-        <Route path='/blog/saas-vs-tradicional' element={<SaasVsTradicionalArticle/>}/>
-        <Route path='/pressupost' element={<Pressupost/>}/>
+        <Route path='/:lang/*' element={<LocalizedRoutes />} />
+        <Route path='*' element={<RedirectToPreferredLanguage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/components/avero.js
+++ b/src/components/components/avero.js
@@ -1,252 +1,208 @@
 import React from 'react';
-import Layout from '../layouts/layout';
 import { Helmet } from 'react-helmet';
+import { Link, useParams } from 'react-router-dom';
+import { Trans, useTranslation } from 'react-i18next';
+
+import Layout from '../layouts/layout';
 import AveroLogo from '../img/AVERO LOGO.png';
 import facturacioImg from '../img/Facturacio_Avero.png';
 import utilitatsImg from '../img/Funcionalitats_Premium.png';
 import aeatImg from '../img/AEAT_Funcions.png';
 import man from '../img/Man.png';
 import woman from '../img/Woman.png';
-// TODO: Afegir imatges i vídeo reals quan estiguin disponibles
-// import GalleryImg1 from '../img/avero-gallery-1.png';
-// import GalleryImg2 from '../img/avero-gallery-2.png';
-// import DemoVideo from '../videos/avero-demo.mp4';
+import { DEFAULT_LANGUAGE } from '../../i18n';
 
-const Avero = () => (
-  <Layout>
-    <Helmet>
-      <title>Avero – Programa de facturació 100% adaptat a VeriFactu i la Llei Crea y Crece</title>
-      <meta
-        name="description"
-        content="Programa de facturació Avero per a autònoms, PIMEs i gestories; compleix Veri*Factu i la Llei Crea y Crece amb una eina senzilla i moderna."
-      />
-    </Helmet>
-    <div className="bg-white text-dark">
-      {/* Hero */}
-      <section className="py-5 bg-light text-center text-md-start" data-aos="fade-up">
-        <div className="container">
-          <div className="row align-items-center g-4 flex-column flex-md-row">
-            <div className="col-md-6">
-              <h1>Avero – Programa de facturació 100% adaptat a VeriFactu i la Llei Crea y Crece.*</h1>
-              <p>La solució més simple i moderna per a autònoms, PIMEs i gestories. Compleix amb la normativa sense complicacions.</p>
-              <div className="d-flex gap-3 mt-3 flex-column flex-sm-row">
-                <a href="https://avero.jctagency.com" className="btn btn-avero">Prova Avero gratis</a>
-                <a href="/contacto" className="btn btn-outline-avero">Demana una demo</a>
+const Avero = () => {
+  const { t } = useTranslation();
+  const { lang } = useParams();
+  const currentLang = lang ?? DEFAULT_LANGUAGE;
+
+  const buildPath = (path = '') => `/${currentLang}${path ? `/${path}` : ''}`;
+
+  const featureBlocks = [
+    { key: 'billing', icon: facturacioImg },
+    { key: 'utilities', icon: utilitatsImg },
+    { key: 'aeat', icon: aeatImg },
+  ];
+
+  const testimonials = [
+    { key: 'man', image: man },
+    { key: 'woman', image: woman },
+  ];
+
+  const footerLinks = [
+    { key: 'verifactu', path: 'programa-de-facturacio-verifactu' },
+    { key: 'aeat', path: 'factures-electroniques-aeat' },
+    { key: 'software', path: 'software-facturacio-autonoms-gestories' },
+  ];
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>{t('avero.meta.title')}</title>
+        <meta
+          name="description"
+          content={t('avero.meta.description')}
+        />
+      </Helmet>
+      <div className="bg-white text-dark">
+        <section className="py-5 bg-light text-center text-md-start" data-aos="fade-up">
+          <div className="container">
+            <div className="row align-items-center g-4 flex-column flex-md-row">
+              <div className="col-md-6">
+                <h1>{t('avero.hero.title')}</h1>
+                <p>{t('avero.hero.description')}</p>
+                <div className="d-flex gap-3 mt-3 flex-column flex-sm-row">
+                  <a href="https://avero.jctagency.com" className="btn btn-avero">
+                    {t('avero.hero.primaryCta')}
+                  </a>
+                  <Link to={buildPath('contacto')} className="btn btn-outline-avero">
+                    {t('avero.hero.secondaryCta')}
+                  </Link>
+                </div>
               </div>
-            </div>
-            <div className="col-md-6 text-center position-relative">
-              <img src={AveroLogo} alt="Mockup Avero" className="img-fluid" style={{ maxWidth: '400px' }} />
-              <span className="badge bg-avero position-absolute top-0 start-50 translate-middle-x mt-2">Adaptat a Veri*Factu – RD 1007/2023</span>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Per què Avero */}
-      <section className="py-5" data-aos="fade-up">
-        <div className="container">
-          <h2>Per què Avero?</h2>
-          <p>Avero és el programari de facturació creat per JCT Agency pensat per a cobrir les noves obligacions legals i simplificar la gestió diària de les empreses. Amb VeriFactu en vigor des de 2025 i l’entrada obligatòria al 2026, necessites un sistema segur, modern i validat per l’AEAT.*</p>
-          <p className="text-muted">Software de facturació VeriFactu · Programa de factures Crea y Crece · Facturació per autònoms i PIMEs</p>
-        </div>
-      </section>
-
-      {/* Funcionalitats clau */}
-      <section className="py-5 bg-light" data-aos="fade-up">
-        <div className="container">
-          <h2 className="mb-4">Funcionalitats clau</h2>
-          <div className="row">
-            {/* Facturació */}
-            <div className="col-md-4 mb-4">
-              <div className="p-4 border-top border-4 border-avero text-center">
-                <img src={facturacioImg} alt="Facturació" style={{ width: '60px' }} className="mb-3" />
-                <h3>Facturació</h3>
-                <ul className="feature-list mb-0 mt-3 text-start">
-                  <li className="mb-2">Factures electròniques (creació, enviament, rectificatives, simplificades).</li>
-                  <li className="mb-2">Gestió de pressupostos i albarans, conversió en factura amb un clic.</li>
-                  <li className="mb-2">Control de clients i proveïdors amb historial complet.</li>
-                  <li className="mb-2">Gestió d’articles i productes (preus, categories, stock bàsic).</li>
-                  <li className="mb-2">Enviament de factures per correu electrònic i PDF professional.</li>
-                  <li className="mb-0">TPV integrat per a vendes físiques amb emissió de tiquets legals.</li>
-                </ul>
-              </div>
-            </div>
-
-            {/* Utilitats premium */}
-            <div className="col-md-4 mb-4">
-              <div className="p-4 border-top border-4 border-avero text-center">
-                <img src={utilitatsImg} alt="Utilitats premium" style={{ width: '60px' }} className="mb-3" />
-                <h3>Utilitats premium</h3>
-                <ul className="feature-list mb-0 mt-3 text-start">
-                  <li className="mb-2">Quadres de comandament i informes: ingressos, despeses, beneficis, IVA.</li>
-                  <li className="mb-2">Gestió multiempresa i multiusuari amb rols i permisos.</li>
-                  <li className="mb-2">Integració amb Stripe i passarel·les de pagament.</li>
-                  <li className="mb-0">Signatura i certificat digital integrat per a remissió segura.</li>
-                </ul>
-              </div>
-            </div>
-
-            {/* AEAT */}
-            <div className="col-md-4 mb-4">
-              <div className="p-4 border-top border-4 border-avero text-center">
-                <img src={aeatImg} alt="AEAT" style={{ width: '60px' }} className="mb-3" />
-                <h3>AEAT</h3>
-                <ul className="feature-list mb-0 mt-3 text-start">
-                  <li className="mb-2">Enviament automàtic a l’AEAT en temps real (modalitat Veri*Factu).</li>
-                  <li className="mb-2">Còpies de seguretat i conservació de registres (complint el RRSIF).</li>
-                  <li className="mb-0">Generació de codi QR tributari a les factures.</li>
-                </ul>
+              <div className="col-md-6 text-center position-relative">
+                <img src={AveroLogo} alt={t('avero.hero.imageAlt')} className="img-fluid" style={{ maxWidth: '400px' }} />
+                <span className="badge bg-avero position-absolute top-0 start-50 translate-middle-x mt-2">
+                  {t('avero.hero.badge')}
+                </span>
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* Compliment legal */}
-      <section className="py-5" data-aos="fade-up">
-        <div className="container">
-          <h2>Compliment legal (Veri*Factu i Llei Crea y Crece)</h2>
-          <p>Veri*Factu: Avero envia cada factura a l’AEAT amb hash encadenat, registre inalterable i QR tributari.</p>
-          <p>Llei Crea y Crece: Factura electrònica obligatòria per a operacions B2B.</p>
-          <p>Normativa aplicable: RD 1007/2023, Ordre HAC/1177/2024 i modificacions RD 254/2025.</p>
-          <p className="text-muted">Avero és el programari de facturació certificat i adaptat al reglament Veri*Factu (AEAT) i a la Llei Crea y Crece.</p>
-        </div>
-      </section>
+        <section className="py-5" data-aos="fade-up">
+          <div className="container">
+            <h2>{t('avero.why.title')}</h2>
+            <p><Trans i18nKey="avero.why.description" components={{ strong: <strong /> }} /></p>
+            <p className="text-muted">{t('avero.why.keywords')}</p>
+          </div>
+        </section>
 
-      {/* Per a qui és Avero */}
-      <section className="py-5 bg-light" data-aos="fade-up">
-        <div className="container">
-          <h2>Per a qui és Avero</h2>
-          <ul className="list-unstyled">
-            <li><strong>Autònoms</strong> → compleix obligacions fiscals sense coneixements tècnics.</li>
-            <li><strong>PIMEs</strong> → controla la facturació, clients i informes.</li>
-            <li><strong>Gestories</strong> → ofereix Avero als clients com a servei extra i guanya en eficiència.</li>
-          </ul>
-        </div>
-      </section>
-
-      {/* Testimonis */}
-      <section className="py-5" data-aos="fade-up">
-        <div className="container">
-          <h2 className="text-center mb-4">Testimonis / Casos d’ús</h2>
-          <div className="row g-4 justify-content-center">
-            <div className="col-md-6 col-lg-5">
-              <div className="p-4 bg-light h-100 text-center rounded">
-                <img
-                  src={man}
-                  alt="Client satisfet"
-                  className="img-fluid rounded-circle mb-3"
-                  style={{ width: '120px', height: '120px', objectFit: 'cover' }}
-                />
-                <blockquote className="blockquote mb-0">
-                  “Amb Avero genero les meves factures en segons i sé que estan validades per l’AEAT.”
-                </blockquote>
-              </div>
-            </div>
-            <div className="col-md-6 col-lg-5">
-              <div className="p-4 bg-light h-100 text-center rounded">
-                <img
-                  src={woman}
-                  alt="Client satisfet"
-                  className="img-fluid rounded-circle mb-3"
-                  style={{ width: '120px', height: '120px', objectFit: 'cover' }}
-                />
-                <blockquote className="blockquote mb-0">
-                  “Hem estalviat hores setmanals en la gestió de clients i IVA.”
-                </blockquote>
-              </div>
+        <section className="py-5 bg-light" data-aos="fade-up">
+          <div className="container">
+            <h2 className="mb-4">{t('avero.features.title')}</h2>
+            <div className="row">
+              {featureBlocks.map(({ key, icon }) => (
+                <div className="col-md-4 mb-4" key={key}>
+                  <div className="p-4 border-top border-4 border-avero text-center">
+                    <img src={icon} alt={t(`avero.features.blocks.${key}.alt`)} style={{ width: '60px' }} className="mb-3" />
+                    <h3>{t(`avero.features.blocks.${key}.title`)}</h3>
+                    <ul className="feature-list mb-0 mt-3 text-start">
+                      {t(`avero.features.blocks.${key}.items`, { returnObjects: true }).map((item, index) => (
+                        <li className="mb-2" key={index}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* Galeria d'imatges */}
-      <section className="py-5 bg-light" data-aos="fade-up">
-        <div className="container">
-          <h2>Galeria</h2>
-          <p>Descobreix captures de pantalla i exemples de l'entorn d'Avero.</p>
-          {/* TODO: Afegir imatges reals de la galeria quan estiguin disponibles.
-          <div className="row g-3">
-            <div className="col-md-4">
-              <img src={GalleryImg1} alt="Captura 1" className="img-fluid rounded" />
+        <section className="py-5" data-aos="fade-up">
+          <div className="container">
+            <h2>{t('avero.compliance.title')}</h2>
+            <ul className="list-unstyled">
+              {t('avero.compliance.items', { returnObjects: true }).map((item, index) => (
+                <li className="mb-2" key={index}>{item}</li>
+              ))}
+            </ul>
+            <p className="text-muted">{t('avero.compliance.note')}</p>
+          </div>
+        </section>
+
+        <section className="py-5 bg-light" data-aos="fade-up">
+          <div className="container">
+            <h2>{t('avero.target.title')}</h2>
+            <p><Trans i18nKey="avero.target.description" components={{ strong: <strong /> }} /></p>
+            <ul>
+              {t('avero.target.items', { returnObjects: true }).map((item, index) => (
+                <li key={index}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="py-5" data-aos="fade-up">
+          <div className="container">
+            <h2>{t('avero.cta.title')}</h2>
+            <p>{t('avero.cta.description')}</p>
+            <div className="d-flex gap-3 flex-column flex-sm-row mt-3">
+              <a href="https://avero.jctagency.com" className="btn btn-avero">
+                {t('avero.cta.primaryCta')}
+              </a>
+              <Link to={buildPath('contacto')} className="btn btn-outline-avero">
+                {t('avero.cta.secondaryCta')}
+              </Link>
             </div>
-            <div className="col-md-4">
-              <img src={GalleryImg2} alt="Captura 2" className="img-fluid rounded" />
+          </div>
+        </section>
+
+        <section className="py-5 bg-white" data-aos="fade-up">
+          <div className="container">
+            <h2 className="text-center mb-4">{t('avero.testimonials.title')}</h2>
+            <div className="row g-4 justify-content-center">
+              {testimonials.map(({ key, image }) => (
+                <div className="col-md-6 col-lg-5" key={key}>
+                  <div className="p-4 bg-light h-100 text-center rounded">
+                    <img
+                      src={image}
+                      alt={t(`avero.testimonials.${key}.alt`)}
+                      className="img-fluid rounded-circle mb-3"
+                      style={{ width: '120px', height: '120px', objectFit: 'cover' }}
+                    />
+                    <blockquote className="blockquote mb-0">
+                      {t(`avero.testimonials.${key}.quote`)}
+                    </blockquote>
+                  </div>
+                </div>
+              ))}
             </div>
-            // Afegir més imatges segons sigui necessari
           </div>
-          */}
-        </div>
-      </section>
+        </section>
 
-      {/* Vídeo explicatiu */}
-      <section className="py-5" data-aos="fade-up">
-        <div className="container">
-          <h2>Vídeo explicatiu</h2>
-          <p>Pròximament disponible: un vídeo que mostra com funciona Avero pas a pas.</p>
-          {/* TODO: Incrustar el vídeo explicatiu quan estigui llest.
-          <div className="ratio ratio-16x9">
-            <video src={DemoVideo} controls></video>
+        <section className="py-5 bg-light" data-aos="fade-up">
+          <div className="container text-center text-md-start">
+            <h2>{t('avero.gallery.title')}</h2>
+            <p>{t('avero.gallery.description')}</p>
           </div>
-          */}
-        </div>
-      </section>
+        </section>
 
-      {/*/!* Plans i preus *!/*/}
-      {/*<section className="py-5 bg-light">*/}
-      {/*  <div className="container">*/}
-      {/*    <h2 className="mb-4">Plans i preus</h2>*/}
-      {/*    <table className="table">*/}
-      {/*      <thead>*/}
-      {/*        <tr>*/}
-      {/*          <th>Pla</th>*/}
-      {/*          <th>Preu</th>*/}
-      {/*        </tr>*/}
-      {/*      </thead>*/}
-      {/*      <tbody>*/}
-      {/*        <tr>*/}
-      {/*          <td>Autònoms</td>*/}
-      {/*          <td>des de XX €/mes</td>*/}
-      {/*        </tr>*/}
-      {/*        <tr>*/}
-      {/*          <td>PIME</td>*/}
-      {/*          <td>des de XX €/mes</td>*/}
-      {/*        </tr>*/}
-      {/*        <tr>*/}
-      {/*          <td>Gestories</td>*/}
-      {/*          <td>pla especial amb múltiples empreses vinculades</td>*/}
-      {/*        </tr>*/}
-      {/*      </tbody>*/}
-      {/*    </table>*/}
-      {/*    <a href="https://avero.jctagency.com" className="btn btn-avero">Consulta els nostres plans</a>*/}
-      {/*  </div>*/}
-      {/*</section>*/}
-
-      {/* CTA final */}
-      <section className="py-5 text-center" style={{ backgroundColor: '#ff8c00' }} data-aos="fade-up">
-        <div className="container">
-          <h2>Adelanta’t a la normativa. Prova Avero avui i compleix amb Veri*Factu sense preocupacions.</h2>
-          <div className="d-flex gap-3 justify-content-center flex-column flex-sm-row mt-3">
-            <a href="https://avero.jctagency.com" className="btn btn-dark">Crear compte</a>
-            <a href="/contacto" className="btn btn-outline-dark text-dark">Contacta amb un assessor</a>
+        <section className="py-5" data-aos="fade-up">
+          <div className="container text-center text-md-start">
+            <h2>{t('avero.video.title')}</h2>
+            <p>{t('avero.video.description')}</p>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* Peu de pàgina */}
-      <footer className="footer-sub py-4">
-        <div className="container text-center text-md-start">
-          <p className="mb-2"><a href="https://avero.jctagency.com">avero.jctagency.com</a></p>
-          <ul className="list-unstyled mb-0">
-            <li><a href="/programa-de-facturacio-verifactu">Programa de facturació VeriFactu</a></li>
-            <li><a href="/factures-electroniques-aeat">Factures electròniques AEAT</a></li>
-            <li><a href="/software-facturacio-autonoms-gestories">Software de facturació per autònoms i gestories</a></li>
-          </ul>
-        </div>
-      </footer>
-    </div>
-  </Layout>
-);
+        <section className="py-5 text-center" style={{ backgroundColor: '#ff8c00' }} data-aos="fade-up">
+          <div className="container">
+            <h2>{t('avero.finalCta.title')}</h2>
+            <div className="d-flex gap-3 justify-content-center flex-column flex-sm-row mt-3">
+              <a href="https://avero.jctagency.com" className="btn btn-dark">{t('avero.finalCta.primaryCta')}</a>
+              <Link to={buildPath('contacto')} className="btn btn-outline-dark text-dark">
+                {t('avero.finalCta.secondaryCta')}
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <footer className="footer-sub py-4">
+          <div className="container text-center text-md-start">
+            <p className="mb-2"><a href="https://avero.jctagency.com">avero.jctagency.com</a></p>
+            <ul className="list-unstyled mb-0">
+              {footerLinks.map(({ key, path }) => (
+                <li key={key}>
+                  <Link to={buildPath(path)}>{t(`avero.footer.links.${key}`)}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </footer>
+      </div>
+    </Layout>
+  );
+};
 
 export default Avero;
-

--- a/src/components/components/blog.js
+++ b/src/components/components/blog.js
@@ -1,71 +1,52 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import Layout from '../layouts/layout';
+import { useTranslation } from 'react-i18next';
 
-const Blog = () => (
-  <Layout>
-    <Helmet>
-      <title>Blog de JCT Agency | Recursos per a PIMEs i gestories</title>
-      <meta
-        name="description"
-        content="Guies de digitalització, SEO i programari Veri*Factu per fer créixer el teu negoci i millorar la gestió empresarial."
-      />
-    </Helmet>
-    <section className="container py-5">
-      <h1 className="mb-4 text-center">Blog</h1>
-      <article className="mb-4">
-        <h2>
-          <Link to="/blog/optimitzacio-seo" className="text-decoration-none">
-            Optimització SEO per a PIMEs: 5 consells clau
-          </Link>
-        </h2>
-        <p className="text-muted">
-          Aprèn com millorar la visibilitat del teu negoci a Google amb tècniques senzilles i efectives.
-        </p>
-      </article>
-      <article className="mb-4">
-        <h2>
-          <Link to="/blog/software-a-mida-beneficis" className="text-decoration-none">
-            Beneficis del software a mida per a gestories i PIMEs
-          </Link>
-        </h2>
-        <p className="text-muted">
-          Descobreix per què invertir en solucions personalitzades pot impulsar l'eficiència del teu negoci.
-        </p>
-      </article>
-      <article className="mb-4">
-        <h2>
-          <Link to="/blog/digitalitzar-pime" className="text-decoration-none">
-            Com digitalitzar la gestió d’una PIME en 5 passos
-          </Link>
-        </h2>
-        <p className="text-muted">
-          Guia pas a pas per modernitzar la teva empresa amb eines digitals accessibles i eficients.
-        </p>
-      </article>
-      <article className="mb-4">
-        <h2>
-          <Link to="/blog/verifactu-gestories" className="text-decoration-none">
-            Guia pràctica per a gestories sobre Veri*Factu
-          </Link>
-        </h2>
-        <p className="text-muted">
-          Tot el que has de saber sobre la nova normativa de facturació i com adaptar-t’hi sense complicacions.
-        </p>
-      </article>
-      <article className="mb-4">
-        <h2>
-          <Link to="/blog/saas-vs-tradicional" className="text-decoration-none">
-            Per què un SaaS és millor que un software tradicional?
-          </Link>
-        </h2>
-        <p className="text-muted">
-          Comparativa entre models per escollir la solució tecnològica més adequada per al teu negoci.
-        </p>
-      </article>
-    </section>
-  </Layout>
-);
+import Layout from '../layouts/layout';
+import { DEFAULT_LANGUAGE } from '../../i18n';
+
+const Blog = () => {
+  const { t } = useTranslation();
+  const { lang } = useParams();
+  const currentLang = lang ?? DEFAULT_LANGUAGE;
+
+  const buildPath = (path = '') => `/${currentLang}${path ? `/${path}` : ''}`;
+
+  const posts = [
+    { path: 'blog/optimitzacio-seo', key: 'blog.posts.seo' },
+    { path: 'blog/software-a-mida-beneficis', key: 'blog.posts.software' },
+    { path: 'blog/digitalitzar-pime', key: 'blog.posts.digital' },
+    { path: 'blog/verifactu-gestories', key: 'blog.posts.verifactu' },
+    { path: 'blog/saas-vs-tradicional', key: 'blog.posts.saas' },
+  ];
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>{t('blog.meta.title')}</title>
+        <meta
+          name="description"
+          content={t('blog.meta.description')}
+        />
+      </Helmet>
+      <section className="container py-5">
+        <h1 className="mb-4 text-center">{t('blog.title')}</h1>
+        {posts.map(({ path, key }) => (
+          <article className="mb-4" key={key}>
+            <h2>
+              <Link to={buildPath(path)} className="text-decoration-none">
+                {t(`${key}.title`)}
+              </Link>
+            </h2>
+            <p className="text-muted">
+              {t(`${key}.excerpt`)}
+            </p>
+          </article>
+        ))}
+      </section>
+    </Layout>
+  );
+};
 
 export default Blog;

--- a/src/components/components/blog/digitalitzar-pime.js
+++ b/src/components/components/blog/digitalitzar-pime.js
@@ -1,107 +1,35 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useTranslation } from 'react-i18next';
+
 import Layout from '../../layouts/layout';
 
-const DigitalitzarPimeArticle = () => (
-  <Layout>
-    <Helmet>
-      <title>Com digitalitzar la gestió d’una PIME en 5 passos | JCT Agency</title>
-      <meta
-        name="description"
-        content="Passos clau per digitalitzar una PIME amb eines SaaS, estratègies de transformació digital i consells pràctics per millorar l'eficiència."
-      />
-    </Helmet>
-    <article className="container py-5">
-      <h1 className="mb-4">Com digitalitzar la gestió d’una PIME en 5 passos</h1>
-      <p>
-        La digitalització ja no és una opció, és una necessitat per a qualsevol PIME que vulgui mantenir-se
-        competitiva. Moltes petites empreses han funcionat durant anys amb processos manuals, documents
-        en paper i eines disperses que compliquen el dia a dia. Aquest article pretén ser una guia detallada
-        perquè qualsevol gestor o propietari pugui iniciar la transformació digital amb confiança. Des de la
-        planificació inicial fins a la implementació d’eines i la formació de l’equip, t’expliquem com fer el
-        pas a un model de gestió més eficient i orientat al futur.
-      </p>
+const DigitalitzarPimeArticle = () => {
+  const { t } = useTranslation();
+  const sections = t('articles.digitalitzarPime.sections', { returnObjects: true });
 
-      <h2 className="mt-4">1. Analitza l’estat actual i defineix objectius</h2>
-      <p>
-        Abans d’adquirir programari o contractar serveis, és essencial entendre com funciona actualment
-        l’empresa. Fes un inventari de processos: comptabilitat, gestió de clients, control d’estoc, tasques
-        administratives i comunicació interna. Identifica els punts febles i aquelles activitats que generen
-        més feina manual. A continuació, defineix objectius concrets de digitalització, com reduir el temps de
-        facturació, millorar la traçabilitat de les comandes o augmentar la satisfacció del client. Aquests
-        objectius han de ser mesurables i alineats amb l’estratègia global de la companyia. Comptar amb
-        indicadors clau de rendiment permetrà valorar els avenços i ajustar el pla quan sigui necessari.
-      </p>
-
-      <h2 className="mt-4">2. Escull les eines adequades</h2>
-      <p>
-        El mercat ofereix una gran varietat d’eines digitals: gestors de facturació, CRMs, plataformes de
-        comunicació, sistemes de gestió de projectes i aplicacions de comerç electrònic, entre d’altres.
-        L’objectiu no és adquirir la solució més cara, sinó aquella que millor s’adapti als processos i
-        pressupost de la PIME. Prioritza les aplicacions en el núvol, que permeten accedir a la informació
-        des de qualsevol lloc i reduir els costos d’infraestructura. Valora també la possibilitat d’utilitzar
-        programes modulars que puguin créixer a mesura que el negoci ho faci. Consulta opinions d’altres
-        usuaris, demana demostracions i assegura’t que l’eina compleix amb la normativa vigent en matèria
-        de protecció de dades i factura electrònica.
-      </p>
-
-      <h2 className="mt-4">3. Integra els sistemes i automatitza processos</h2>
-      <p>
-        Un cop seleccionades les eines, el següent pas és garantir que totes treballin de manera coordinada.
-        Les integracions permeten que les dades circulin sense errors ni duplicacions. Per exemple, el CRM
-        pot estar connectat amb el programa de facturació perquè les vendes es reflecteixin automàticament
-        en la comptabilitat. També es poden automatitzar tasques com l’enviament de correus de seguiment,
-        la generació d’informes o la sincronització d’estoc entre la botiga física i l’online. Dedica temps a
-        definir els fluxos d’informació i utilitza APIs o connectors proporcionats pels proveïdors. Una bona
-        integració no només estalvia temps, sinó que ofereix una visió global del negoci, facilitant la presa de
-        decisions basada en dades.
-      </p>
-
-      <h2 className="mt-4">4. Forma l’equip i promou la cultura digital</h2>
-      <p>
-        La tecnologia per si sola no garanteix l’èxit. És fonamental que les persones que la utilitzaran se sentin
-        còmodes i entenguin els avantatges del canvi. Organitza sessions de formació adaptades a cada
-        departament i crea materials de suport com manuals o vídeos curts. Promou una cultura digital on
-        l’aprenentatge continu sigui valorat i els errors es considerin una oportunitat de millora. Implica els
-        treballadors en el procés, demanant la seva opinió i permetent-los proposar idees. Quan l’equip veu que
-        la digitalització facilita la seva feina i elimina tasques repetitives, l’adopció és molt més ràpida i
-        natural.
-      </p>
-
-      <h2 className="mt-4">5. Mesura resultats i ajusta l’estratègia</h2>
-      <p>
-        La transformació digital és un camí continu. Després d’implantar les eines i formar l’equip, és
-        important establir un sistema de seguiment que permeti mesurar l’impacte. Utilitza indicadors com
-        el temps de resposta als clients, el nombre d’errors en la facturació o el cost de gestió per projecte.
-        Compara aquests valors amb els objectius inicials i detecta àrees de millora. Pot ser que calgui
-        afegir noves funcionalitats, canviar un proveïdor o reforçar la formació en determinats punts. La
-        flexibilitat és clau: la digitalització no és un projecte amb principi i final, sinó una evolució constant
-        que ha d’acompanyar el creixement del negoci.
-      </p>
-
-      <h2 className="mt-4">Beneficis addicionals de la digitalització</h2>
-      <p>
-        A més d’optimitzar processos, la digitalització aporta una sèrie de beneficis transversals. Permet
-        treballar de manera col·laborativa, independentment de la ubicació dels membres de l’equip, i
-        facilita l’accés a noves oportunitats de negoci a través d’Internet. La disponibilitat de dades en temps
-        real millora la presa de decisions i redueix els riscos. També contribueix a una imatge de marca més
-        professional i innovadora, fet que pot atreure nous clients i partners. Finalment, moltes eines digitals
-        estan preparades per complir amb normatives com el RGPD o VeriFactu, cosa que simplifica el
-        compliment legal i evita sancions.
-      </p>
-
-      <h2 className="mt-4">Conclusió</h2>
-      <p>
-        Digitalitzar una PIME no ha de ser un procés traumàtic. Amb una planificació adequada i el suport
-        de professionals, és possible transformar l’empresa de manera gradual i rendible. L’important és
-        començar amb objectius clars, escollir les eines correctes i implicar tot l’equip en el canvi. A JCT
-        Agency hem ajudat nombroses empreses a donar aquest pas, i sabem que els resultats arriben quan la
-        tecnologia es combina amb una visió estratègica. Si estàs preparat per modernitzar la gestió del teu
-        negoci, la digitalització és el camí que et permetrà créixer i afrontar amb garanties els reptes del
-        futur.
-      </p>
-    </article>
-  </Layout>
-);
+  return (
+    <Layout>
+      <Helmet>
+        <title>{t('articles.digitalitzarPime.meta.title')}</title>
+        <meta
+          name="description"
+          content={t('articles.digitalitzarPime.meta.description')}
+        />
+      </Helmet>
+      <article className="container py-5">
+        <h1 className="mb-4">{t('articles.digitalitzarPime.title')}</h1>
+        {sections.map((section, index) => (
+          <div key={index} className="article-section">
+            {section.heading && <h2 className="mt-4">{section.heading}</h2>}
+            {section.paragraphs.map((paragraph, paragraphIndex) => (
+              <p key={paragraphIndex}>{paragraph}</p>
+            ))}
+          </div>
+        ))}
+      </article>
+    </Layout>
+  );
+};
 
 export default DigitalitzarPimeArticle;

--- a/src/components/components/blog/saas-vs-tradicional.js
+++ b/src/components/components/blog/saas-vs-tradicional.js
@@ -1,129 +1,35 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useTranslation } from 'react-i18next';
+
 import Layout from '../../layouts/layout';
 
-const SaasVsTradicionalArticle = () => (
-  <Layout>
-    <Helmet>
-      <title>Per què un SaaS és millor que un software tradicional? | JCT Agency</title>
-      <meta
-        name="description"
-        content="Comparativa entre SaaS i software tradicional per escollir la millor opció en costos, escalabilitat i seguretat per al teu negoci."
-      />
-    </Helmet>
-    <article className="container py-5">
-      <h1 className="mb-4">Per què un SaaS és millor que un software tradicional?</h1>
-      <p>
-        Quan una empresa necessita una nova eina de gestió, sovint es planteja si optar per un software
-        tradicional instal·lat en servidors propis o bé per una solució SaaS (Software as a Service) allotjada al
-        núvol. La decisió té implicacions en costos, manteniment, escalabilitat i seguretat. En aquest article
-        analitzarem en profunditat les diferències entre ambdós models perquè puguis escollir el que millor s’adapti
-        al teu negoci. La tendència actual apunta clarament cap al SaaS, però és important conèixer els motius
-        que hi ha darrere i les situacions en què un enfocament tradicional podria seguir tenint sentit.
-      </p>
+const SaasVsTradicionalArticle = () => {
+  const { t } = useTranslation();
+  const sections = t('articles.saas.sections', { returnObjects: true });
 
-      <h2 className="mt-4">1. Costos inicials i model de pagament</h2>
-      <p>
-        Les solucions tradicionals requereixen una inversió inicial elevada en llicències, maquinari i
-        infraestructura. A més, cal considerar el cost de manteniment i actualitzacions, sovint gestionades per
-        un equip intern. El model SaaS, en canvi, es basa en subscripcions mensuals o anuals que inclouen
-        suport, actualitzacions i allotjament. Això permet distribuir la despesa en el temps i facilita que les
-        PIMEs puguin accedir a tecnologies avançades sense un gran desemborsament inicial. A llarg termini,
-        el cost total pot ser inferior gràcies a la reducció de tasques internes i a l’escalabilitat de la
-        plataforma.
-      </p>
-
-      <h2 className="mt-4">2. Implementació i posada en marxa</h2>
-      <p>
-        Instal·lar un software tradicional pot requerir setmanes o mesos de configuració. Cal preparar
-        servidors, garantir compatibilitats i realitzar proves exhaustives abans de fer-lo servir. Les solucions
-        SaaS, per contra, estan disponibles gairebé de manera immediata: només cal crear un compte i
-        personalitzar alguns paràmetres. Aquesta rapidesa és clau per a empreses que necessiten reaccionar
-        ràpidament davant canvis del mercat o oportunitats de creixement. A més, en el model SaaS no
-        cal preocupar-se per les actualitzacions, que s’apliquen automàticament sense interrompre el servei.
-      </p>
-
-      <h2 className="mt-4">3. Escalabilitat i flexibilitat</h2>
-      <p>
-        Quan el negoci creix, el software ha de ser capaç de créixer també. Amb un sistema tradicional,
-        ampliar capacitat implica adquirir nous servidors, instal·lar llicències i fer migracions complexes. En
-        canvi, amb el SaaS normalment només cal canviar de pla o afegir usuaris des del panell d’administració.
-        Això ofereix una flexibilitat enorme i permet adaptar-se a pics de demanda o a expansions
-        internacionals sense grans inversions. A més, moltes plataformes SaaS inclouen APIs que faciliten la
-        integració amb altres serveis, cosa que amplifica les possibilitats d’innovació.
-      </p>
-
-      <h2 className="mt-4">4. Seguretat i còpies de seguretat</h2>
-      <p>
-        Un dels temors habituals a l’hora de migrar al núvol és la seguretat de les dades. No obstant això,
-        els proveïdors SaaS dediquen recursos significatius a protegir la informació dels seus clients: xifrat
-        avançat, certificacions de seguretat i equips especialitzats en ciberseguretat. Les còpies de seguretat
-        es realitzen de manera automàtica i els centres de dades disposen de mesures de redundància per
-        garantir la continuïtat del servei. En un entorn tradicional, aquesta responsabilitat recau en l’empresa,
-        que sovint no té els recursos ni el coneixement per implementar protocols igual de robustos.
-      </p>
-
-      <h2 className="mt-4">5. Mobilitat i treball col·laboratiu</h2>
-      <p>
-        El model SaaS està pensat per ser utilitzat des de qualsevol dispositiu amb connexió a Internet.
-        Això facilita el teletreball i la col·laboració entre equips distribuïts. Els canvis es sincronitzen en temps
-        real i tots els membres treballen sobre la mateixa versió del document o del projecte. Amb un
-        software tradicional, l’accés remot requereix configuracions complexes de VPN o es limita a
-        determinats ordinadors, cosa que dificulta la flexibilitat. En un món on la mobilitat és cada vegada
-        més important, el SaaS proporciona una experiència fluida i centrada en l’usuari.
-      </p>
-
-      <h2 className="mt-4">6. Actualitzacions i noves funcionalitats</h2>
-      <p>
-        Les empreses que utilitzen software tradicional sovint es queden enrere pel que fa a noves
-        funcionalitats. Implementar una actualització pot suposar aturades del servei i costos addicionals.
-        En canvi, els proveïdors SaaS despleguen millores de manera contínua, basant-se en el feedback dels
-        usuaris i en l’evolució del mercat. Això significa que els clients sempre tenen accés a les últimes
-        innovacions sense haver de fer res. Aquesta capacitat d’evolució constant és especialment útil en
-        entorns canviants on la competitivitat depèn de l’agilitat.
-      </p>
-
-      <h2 className="mt-4">7. Personalització i integració</h2>
-      <p>
-        Una crítica habitual al SaaS és que ofereix menys personalització que el software tradicional. Tot i
-        que algunes solucions del núvol són tancades, cada cop més proveïdors permeten personalitzar
-        fluxos de treball, camps i interfícies. A més, la possibilitat d’integrar-se amb altres plataformes mitjançant
-        APIs compensa aquesta limitació, ja que permet construir ecosistemes adaptats a les necessitats de
-        cada empresa. En el cas del software tradicional, la personalització pot ser més profunda, però també
-        implica costos elevats i dificulta les actualitzacions futures.
-      </p>
-
-      <h2 className="mt-4">8. Dependència del proveïdor</h2>
-      <p>
-        Amb el SaaS es depèn del proveïdor per accedir al servei i a les dades. Per això és essencial triar
-        empreses de confiança, amb garanties de disponibilitat i polítiques clares d’exportació de dades. Molts
-        proveïdors ofereixen mecanismes per descarregar la informació en formats estàndard, assegurant que
-        el client pugui migrar si ho necessita. En el model tradicional, tot i tenir un control més directe,
-        l’empresa pot quedar atrapada en tecnologies obsoletes si el proveïdor deixa de donar suport o si
-        el desenvolupament intern es torna insostenible.
-      </p>
-
-      <h2 className="mt-4">9. Sostenibilitat i impacte ambiental</h2>
-      <p>
-        Les solucions SaaS solen operar en centres de dades optimitzats energèticament i amb certificacions
-        d’eficiència. Compartir recursos entre múltiples clients redueix el consum global i minimitza l’ús de
-        maquinari redundant. En canvi, mantenir servidors propis implica un consum energètic elevat i
-        renovacions de hardware periòdiques. Per a empreses compromeses amb la sostenibilitat, el model
-        SaaS pot contribuir a reduir la petjada de carboni i a complir objectius de responsabilitat social.
-      </p>
-
-      <h2 className="mt-4">10. Conclusions</h2>
-      <p>
-        L’elecció entre SaaS i software tradicional depèn de les necessitats i recursos de cada empresa, però
-        la balança s’inclina cada vegada més cap al núvol per la seva flexibilitat, cost eficient i seguretat. Les
-        PIMEs i gestories que opten pel SaaS gaudeixen d’una implementació ràpida, actualitzacions
-        automàtiques i possibilitats d’escalat gairebé il·limitades. Tot i això, és important avaluar cada cas
-        i assegurar-se que el proveïdor compleix els estàndards de qualitat i de protecció de dades. Amb una
-        anàlisi acurada i el suport adequat, adoptar un SaaS pot ser un pas decisiu per modernitzar el teu
-        negoci i preparar-lo per als reptes digitals del futur.
-      </p>
-    </article>
-  </Layout>
-);
+  return (
+    <Layout>
+      <Helmet>
+        <title>{t('articles.saas.meta.title')}</title>
+        <meta
+          name="description"
+          content={t('articles.saas.meta.description')}
+        />
+      </Helmet>
+      <article className="container py-5">
+        <h1 className="mb-4">{t('articles.saas.title')}</h1>
+        {sections.map((section, index) => (
+          <div key={index} className="article-section">
+            {section.heading && <h2 className="mt-4">{section.heading}</h2>}
+            {section.paragraphs.map((paragraph, paragraphIndex) => (
+              <p key={paragraphIndex}>{paragraph}</p>
+            ))}
+          </div>
+        ))}
+      </article>
+    </Layout>
+  );
+};
 
 export default SaasVsTradicionalArticle;

--- a/src/components/components/blog/seo.js
+++ b/src/components/components/blog/seo.js
@@ -1,144 +1,35 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useTranslation } from 'react-i18next';
+
 import Layout from '../../layouts/layout';
 
-const SeoArticle = () => (
-  <Layout>
-    <Helmet>
-      <title>Optimització SEO per a PIMEs: guia completa | JCT Agency</title>
-      <meta
-        name="description"
-        content="Guia SEO per a PIMEs amb tècniques per posicionar la web a Google, atraure clients locals i optimitzar continguts."
-      />
-    </Helmet>
-    <article className="container py-5">
-      <h1 className="mb-4">Optimització SEO per a PIMEs: guia completa</h1>
-      <p>
-        El posicionament orgànic en cercadors és un dels pilars per generar trànsit qualificat cap a la
-        teva web sense dependre exclusivament de la publicitat de pagament. Per a una PIME, invertir en
-        SEO significa establir una base sòlida que li permeti competir amb empreses més grans i arribar
-        a nous clients potencials. En aquesta guia aprofundirem en les principals estratègies que pots
-        aplicar avui mateix. L’article està pensat perquè sigui una referència completa: trobaràs
-        recomanacions pràctiques, exemples reals i consells sobre com implementar-les amb recursos
-        limitats. L’objectiu és que puguis entendre cada pas i portar-lo a la pràctica sense necessitat de
-        coneixements tècnics avançats.
-      </p>
+const SeoArticle = () => {
+  const { t } = useTranslation();
+  const sections = t('articles.seo.sections', { returnObjects: true });
 
-      <h2 className="mt-4">1. Investigació de paraules clau</h2>
-      <p>
-        Abans de redactar qualsevol peça de contingut és imprescindible saber quins termes utilitzen els
-        teus clients quan busquen informació relacionada amb el teu producte o servei. Comença fent una
-        llista de possibles paraules i expressions, incloent sinònims i consultes de llarga cua. Eines com
-        Google Keyword Planner, Ubersuggest o AnswerThePublic et permeten conèixer el volum de cerques,
-        la dificultat i les tendències. Dedica temps a entendre la intenció de cada cerca: no és el mateix
-        “gestoria per autònoms a Barcelona” que “com portar la comptabilitat d’un autònom”. Aquesta fase
-        et servirà per crear contingut que respongui exactament el que necessita l’usuari, millorant la
-        rellevància i augmentant les opcions d’aparèixer als primers resultats de Google.
-      </p>
-
-      <h2 className="mt-4">2. Contingut de qualitat i estratègia editorial</h2>
-      <p>
-        Una vegada identificades les paraules clau, és hora de desenvolupar una estratègia editorial. El
-        contingut ha de ser útil, original i centrat en resoldre problemes reals. Planifica un calendari de
-        publicacions que combini articles informatius, guies i casos d’èxit. És recomanable mantenir una
-        estructura clara amb títols, subtítols i llistes que facilitin la lectura. Inclou imatges optimitzades
-        amb textos alternatius descriptius i, sempre que sigui possible, afegeix exemples propis de la teva
-        activitat empresarial. Recorda que l’actualització periòdica del contingut és clau: Google valora les
-        webs que es mantenen vives i que aporten novetats de forma constant. A més, una bona estratègia
-        editorial afavoreix que altres webs enllacin als teus articles, incrementant l’autoritat del domini.
-      </p>
-
-      <h2 className="mt-4">3. SEO local i fitxes de Google Business</h2>
-      <p>
-        Si el teu negoci té una ubicació física o presta serveis en una zona geogràfica concreta, treballar el
-        SEO local és imprescindible. El primer pas és crear i optimitzar la fitxa de Google Business Profile,
-        assegurant-te que la informació de contacte, horaris i categories és correcta. Anima els teus clients a
-        deixar ressenyes i respon-les sempre, ja que són un factor de posicionament i reforcen la confiança.
-        Al web, inclou la teva localització a les pàgines de serveis i al peu de pàgina, utilitzant dades
-        estructurades perquè els cercadors entenguin millor on operes. Publicar contingut relacionat amb la
-        teva ciutat o comarca també ajuda a atraure trànsit qualificat que busca solucions a prop seu.
-      </p>
-
-      <h2 className="mt-4">4. Optimització tècnica de la web</h2>
-      <p>
-        Una web ràpida i sense errors és fonamental perquè el teu esforç en continguts doni resultats. Revisa
-        periòdicament la velocitat de càrrega amb eines com PageSpeed Insights o Lighthouse i aplica les
-        millores recomanades: compressió d’imatges, minificació de recursos i implementació de memòria
-        cau. El web ha de ser totalment responsive, adaptant-se a mòbils i tauletes, i utilitzar el protocol
-        HTTPS per garantir la seguretat. També és important disposar d’un mapa del lloc i un fitxer robots.txt
-        correctament configurats perquè Google pugui rastrejar les pàgines sense problemes. Els errors 404
-        i els enllaços trencats han de solucionar-se ràpidament per evitar penalitzacions i mala experiència
-        d’usuari.
-      </p>
-
-      <h2 className="mt-4">5. Estratègia d’enllaçat intern</h2>
-      <p>
-        Crear una xarxa d’enllaços interna coherent facilita que els cercadors entenguin l’estructura del teu
-        lloc i distribueix l’autoritat entre les diferents pàgines. Cada vegada que publiquis un nou article,
-        enllaça’l amb contingut relacionat que ja existeixi al teu web. Això prolonga el temps de sessió dels
-        usuaris i redueix la taxa de rebot. Utilitza textos d’àncora descriptius, evitant frases genèriques com
-        “fes clic aquí”. Les pàgines més importants haurien de rebre més enllaços interns, i és recomanable
-        fer un seguiment regular per detectar oportunitats d’enllaçat que ajudin a posicionar paraules clau
-        concretes. Un bon enllaçat intern també serveix per guiar l’usuari cap a la conversió, ja sigui omplir
-        un formulari, descarregar un recurs o contractar un servei.
-      </p>
-
-      <h2 className="mt-4">6. Link building i col·laboracions</h2>
-      <p>
-        Els enllaços que provenen d’altres webs continuen sent un dels factors de posicionament més rellevants.
-        Per a una PIME, la clau és aconseguir backlinks de qualitat sense recórrer a pràctiques dubtoses.
-        Pots col·laborar amb blogs del teu sector, participar en esdeveniments i publicar notes de premsa en
-        mitjans locals. Els directors d’empreses, associacions professionals o proveïdors també poden
-        enllaçar el teu lloc si ofereixes contingut d’interès. Prioritza la qualitat sobre la quantitat: un sol
-        enllaç d’una web amb autoritat pot ser més valuós que desenes de baixa qualitat. A més, diversifica
-        els textos d’àncora i evita un patró artificial que pugui aixecar sospites als algoritmes de Google.
-      </p>
-
-      <h2 className="mt-4">7. Experiència d’usuari i Core Web Vitals</h2>
-      <p>
-        Google ha incorporat les Core Web Vitals com a indicador clau de l’experiència d’usuari. Aquests
-        paràmetres mesuren la velocitat de càrrega, l’estabilitat visual i la interactivitat de la pàgina. Per
-        optimitzar-los, redueix els scripts innecessaris, utilitza fonts web eficients i reserva espai per a les
-        imatges per evitar moviments inesperats. Una experiència d’usuari positiva no només ajuda al
-        posicionament, sinó que també augmenta la probabilitat de conversió. Recorda que el SEO i la
-        usabilitat van de la mà: quan l’usuari troba ràpidament allò que busca i navega sense dificultats,
-        és més probable que torni i recomani el teu web.
-      </p>
-
-      <h2 className="mt-4">8. Analítica i millora contínua</h2>
-      <p>
-        Ninguna estratègia SEO està completa sense un sistema de mesura que permeti avaluar els resultats.
-        Configura Google Analytics i Google Search Console per monitoritzar el trànsit, les paraules clau
-        que generen visites i el comportament dels usuaris. Estableix objectius clars, com ara conversions o
-        descàrregues, i fes un seguiment periòdic per identificar quines pàgines funcionen millor. L’analítica
-        també serveix per detectar contingut obsolet o paraules clau emergents que val la pena treballar. El
-        SEO és un procés iteratiu: analitza, aprèn i aplica millores constants per mantenir-te per davant de la
-        competència.
-      </p>
-
-      <h2 className="mt-4">9. Automatització i eines de suport</h2>
-      <p>
-        Tot i que moltes accions SEO es poden fer manualment, utilitzar eines d’automatització pot estalviar
-        temps i recursos. Plataformes com Screaming Frog, SEMrush o Ahrefs permeten auditar el web,
-        detectar errors tècnics i monitoritzar l’estratègia de link building. També pots programar alertes per
-        conèixer quan un competidor publica nou contingut o quan rep un enllaç rellevant. L’automatització
-        no substitueix la creativitat ni la planificació estratègica, però sí que facilita la gestió del dia a dia i
-        permet concentrar-te en tasques de més valor, com la creació de contingut o el desenvolupament de
-        nous serveis.
-      </p>
-
-      <h2 className="mt-4">10. Conclusions i pròxims passos</h2>
-      <p>
-        Implementar una estratègia SEO efectiva requereix constància i una visió a llarg termini. Les PIMEs
-        que aposten per aquesta disciplina aconsegueixen una presència en línia més sòlida, un flux de
-        clients potencials sostingut i una imatge de marca reforçada. Comença pels aspectes bàsics: una bona
-        investigació de paraules clau, contingut rellevant i una web tècnicament optimitzada. A mesura que
-        vagis obtenint resultats, amplia les accions amb estratègies de link building, millores d’experiència
-        d’usuari i automatització. Recorda que el SEO és una carrera de fons: cada acció suma i, amb
-        perseverança, el teu negoci pot destacar en un entorn digital cada vegada més competitiu.
-      </p>
-    </article>
-  </Layout>
-);
+  return (
+    <Layout>
+      <Helmet>
+        <title>{t('articles.seo.meta.title')}</title>
+        <meta
+          name="description"
+          content={t('articles.seo.meta.description')}
+        />
+      </Helmet>
+      <article className="container py-5">
+        <h1 className="mb-4">{t('articles.seo.title')}</h1>
+        {sections.map((section, index) => (
+          <div key={index} className="article-section">
+            {section.heading && <h2 className="mt-4">{section.heading}</h2>}
+            {section.paragraphs.map((paragraph, paragraphIndex) => (
+              <p key={paragraphIndex}>{paragraph}</p>
+            ))}
+          </div>
+        ))}
+      </article>
+    </Layout>
+  );
+};
 
 export default SeoArticle;

--- a/src/components/components/blog/software.js
+++ b/src/components/components/blog/software.js
@@ -1,131 +1,35 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useTranslation } from 'react-i18next';
+
 import Layout from '../../layouts/layout';
 
-const SoftwareArticle = () => (
-  <Layout>
-    <Helmet>
-      <title>Beneficis del software a mida per a gestories i PIMEs | JCT Agency</title>
-      <meta
-        name="description"
-        content="Beneficis del software a mida per a gestories i PIMEs: automatitza processos, integra eines i impulsa el creixement empresarial."
-      />
-    </Helmet>
-    <article className="container py-5">
-      <h1 className="mb-4">Beneficis del software a mida per a gestories i PIMEs</h1>
-      <p>
-        Les empreses que busquen diferenciar-se i optimitzar processos sovint es troben amb limitacions
-        quan utilitzen programes genèrics. El software a mida, desenvolupat pensant en les necessitats
-        concretes de cada negoci, ofereix una alternativa potent per guanyar eficiència i agilitat. En aquest
-        article explorem amb profunditat els motius pels quals la personalització tecnològica pot ser clau per
-        a gestories i petites o mitjanes empreses, així com els passos per implementar un projecte amb èxit.
-      </p>
+const SoftwareArticle = () => {
+  const { t } = useTranslation();
+  const sections = t('articles.software.sections', { returnObjects: true });
 
-      <h2 className="mt-4">1. Adaptació total als processos interns</h2>
-      <p>
-        Cada empresa té un funcionament propi, amb procediments i fluxos de treball que la fan única. Els
-        programes estàndard obliguen sovint a adaptar-se a la lògica de l’eina, cosa que genera friccions i
-        temps perdut. En canvi, el software a mida permet incorporar exactament les funcionalitats que el
-        teu equip necessita. Això redueix la corba d’aprenentatge i evita que els empleats hagin de buscar
-        solucions alternatives, com fulls de càlcul o processos manuals que acaben provocant errors. La
-        personalització garanteix que l’eina creixi a la mateixa velocitat que el negoci i s’adeqüi a la seva
-        manera de treballar.
-      </p>
-
-      <h2 className="mt-4">2. Automatització de tasques repetitives</h2>
-      <p>
-        Una de les grans avantatges del software a mida és la capacitat d’automatitzar tasques que consumeixen
-        hores de treball. Generar informes periòdics, validar dades, enviar recordatoris als clients o
-        sincronitzar informació entre departaments són processos que es poden programar perquè s’executin
-        de manera automàtica. L’automatització redueix els errors humans i permet que els professionals es
-        concentrin en tasques de major valor afegit, com l’assessorament estratègic o la captació de nous
-        clients. Amb una bona planificació, és possible identificar els punts crítics del flux de treball i
-        convertir-los en processos simples i predictibles.
-      </p>
-
-      <h2 className="mt-4">3. Millor control de la informació i seguretat</h2>
-      <p>
-        Les gestories gestionen dades sensibles de tercers i les PIMEs sovint manejen informació confidencial
-        sobre finances, contractes o dades personals. Utilitzar software propi permet controlar amb precisió
-        qui accedeix a cada funcionalitat i quines dades es poden consultar o modificar. També facilita
-        l’aplicació de polítiques de seguretat avançades, com el xifrat de dades o l’autenticació de dos
-        factors. Tenir el control del codi i de la infraestructura redueix el risc d’exposició i facilita el
-        compliment de normatives com el RGPD, element fonamental per mantenir la confiança dels clients.
-      </p>
-
-      <h2 className="mt-4">4. Integració amb altres sistemes</h2>
-      <p>
-        En l’entorn empresarial actual és habitual utilitzar diverses aplicacions per gestionar diferents
-        àrees del negoci: comptabilitat, facturació, CRM, eines de màrqueting, etc. El software a mida es pot
-        dissenyar perquè es comuniqui de manera fluida amb aquests sistemes, evitant duplicitats i errors de
-        transcripció. Les APIs i els connectors personalitzats permeten que la informació flueixi entre
-        departaments i que les dades estiguin sempre actualitzades. Aquesta integració resulta especialment
-        útil per a gestories que treballen amb múltiples plataformes dels seus clients i necessiten unificar la
-        informació en un sol lloc.
-      </p>
-
-      <h2 className="mt-4">5. Escalabilitat i flexibilitat a llarg termini</h2>
-      <p>
-        Les necessitats d’una empresa evolucionen amb el temps. Un programari genèric pot quedar-se curt
-        quan el negoci creix o apareixen noves regulacions. El software a mida està pensat perquè es pugui
-        ampliar amb mòduls o funcionalitats addicionals sense haver de començar des de zero. Aquesta
-        escalabilitat garanteix que la inversió inicial continuï aportant valor durant anys. A més, el proveïdor
-        que ha desenvolupat l’eina coneix el projecte a fons i pot proposar millores contínues en funció de les
-        noves necessitats que vagin sorgint.
-      </p>
-
-      <h2 className="mt-4">6. Costos i retorn de la inversió</h2>
-      <p>
-        Tot i que el desenvolupament d’un software personalitzat pot semblar una despesa elevada, és
-        important analitzar el retorn que pot oferir. L’estalvi en hores de treball, la reducció d’errors i la
-        millora en l’atenció al client es tradueixen en ingressos addicionals i en una major satisfacció del
-        personal. A més, en no dependre de llicències de tercers, s’eviten costos recurrents i es manté el
-        control del projecte. Moltes empreses recuperen la inversió en pocs mesos gràcies a l’eficiència
-        operativa que aconsegueixen amb una eina dissenyada a mida.
-      </p>
-
-      <h2 className="mt-4">7. Casos d’èxit i exemples reals</h2>
-      <p>
-        Diverses gestories que han apostat per un software a mida expliquen que han reduït fins a un 40% el
-        temps dedicat a tasques administratives. Altres PIMEs han integrat el seu programa de facturació amb
-        la botiga en línia i el CRM, aconseguint una visió completa de les vendes i de l’estoc en temps real.
-        Aquestes històries demostren que la personalització no és només una qüestió tècnica, sinó una eina
-        de transformació empresarial. Implementar un projecte a mida implica col·laborar estretament amb
-        el proveïdor tecnològic, definir objectius clars i fer proves pilot que validin les funcionalitats abans
-        d’escalar-les a tota l’organització.
-      </p>
-
-      <h2 className="mt-4">8. Com escollir el proveïdor adequat</h2>
-      <p>
-        Triar l’equip que desenvoluparà el software és una decisió crítica. Cal buscar professionals amb
-        experiència en el sector i que entenguin els reptes específics del negoci. És recomanable demanar
-        referències, revisar projectes anteriors i assegurar-se que existeix una comunicació fluida durant tot
-        el procés. Un bon proveïdor ha d’oferir suport tècnic, manteniment i possibilitats d’evolució del
-        producte. També és important definir des del principi els terminis, els costos i els criteris d’acceptació
-        de cada fase per evitar malentesos.
-      </p>
-
-      <h2 className="mt-4">9. Implementació i formació de l’equip</h2>
-      <p>
-        Desplegar un nou software requereix una planificació acurada. Abans de la posada en marxa és
-        convenient fer proves amb un grup reduït d’usuaris i recollir feedback. La formació és un altre punt
-        clau: els empleats han d’entendre les funcionalitats i els beneficis de la nova eina per adoptar-la
-        sense resistències. Proporcionar manuals, tutorials i sessions de suport inicial garanteix una
-        transició suau. A mesura que s’utilitza, és habitual descobrir millores que es poden incorporar en
-        iteracions futures.
-      </p>
-
-      <h2 className="mt-4">10. Conclusions</h2>
-      <p>
-        El software a mida és una inversió estratègica per a gestories i PIMEs que busquen creixement i
-        eficiència. Permet adaptar-se als processos interns, automatitzar tasques, millorar la seguretat i
-        integrar sistemes diversos. Tot plegat es tradueix en un avantatge competitiu difícil d’assolir amb
-        solucions estàndard. Amb una planificació adequada i el suport d’un proveïdor de confiança, un
-        projecte personalitzat pot transformar el dia a dia d’una organització i preparar-la per a reptes
-        futurs en un mercat cada cop més digitalitzat.
-      </p>
-    </article>
-  </Layout>
-);
+  return (
+    <Layout>
+      <Helmet>
+        <title>{t('articles.software.meta.title')}</title>
+        <meta
+          name="description"
+          content={t('articles.software.meta.description')}
+        />
+      </Helmet>
+      <article className="container py-5">
+        <h1 className="mb-4">{t('articles.software.title')}</h1>
+        {sections.map((section, index) => (
+          <div key={index} className="article-section">
+            {section.heading && <h2 className="mt-4">{section.heading}</h2>}
+            {section.paragraphs.map((paragraph, paragraphIndex) => (
+              <p key={paragraphIndex}>{paragraph}</p>
+            ))}
+          </div>
+        ))}
+      </article>
+    </Layout>
+  );
+};
 
 export default SoftwareArticle;

--- a/src/components/components/blog/verifactu-gestories.js
+++ b/src/components/components/blog/verifactu-gestories.js
@@ -1,135 +1,35 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useTranslation } from 'react-i18next';
+
 import Layout from '../../layouts/layout';
 
-const VerifactuGestoriesArticle = () => (
-  <Layout>
-    <Helmet>
-      <title>Guia pràctica per a gestories sobre Veri*Factu | JCT Agency</title>
-      <meta
-        name="description"
-        content="Guia per a gestories sobre Veri*Factu: requisits de l'AEAT, passos d'implantació i recomanacions per garantir el compliment legal."
-      />
-    </Helmet>
-    <article className="container py-5">
-      <h1 className="mb-4">Guia pràctica per a gestories sobre Veri*Factu</h1>
-      <p>
-        El sistema Veri*Factu és una de les principals novetats legals que afecten les empreses espanyoles
-        en matèria de facturació. Pensat per garantir la integritat i traçabilitat de les factures, obliga a
-        utilitzar programes homologats que enviïn informació a l’Agència Tributària de manera segura i
-        fiable. Per a les gestories, entendre com funciona i com adaptar-s’hi és imprescindible, ja que els seus
-        clients confiaran en elles per complir amb la normativa sense complicacions. En aquesta guia
-        aprofundirem en els requisits de Veri*Factu, els beneficis que ofereix i els passos que cal seguir per
-        implementar-lo amb èxit.
-      </p>
+const VerifactuGestoriesArticle = () => {
+  const { t } = useTranslation();
+  const sections = t('articles.verifactu.sections', { returnObjects: true });
 
-      <h2 className="mt-4">1. Què és Veri*Factu i per què s’ha creat?</h2>
-      <p>
-        Veri*Factu és un sistema desenvolupat per l’Agència Tributària espanyola per assegurar que totes les
-        factures emeses per les empreses siguin íntegres, inalterables i traçables. El seu objectiu és prevenir
-        l’ocultació d’ingressos i reduir el frau fiscal. Els programes de facturació han de generar fitxers amb
-        un format específic i enviar-los de forma automàtica a l’Administració. Això no només incrementa la
-        transparència, sinó que simplifica les inspeccions i facilita la gestió documental. Per a una gestoria,
-        conèixer aquests requisits és essencial per assessorar correctament els seus clients i evitar sancions.
-      </p>
-
-      <h2 className="mt-4">2. Requisits tècnics dels programes Veri*Factu</h2>
-      <p>
-        Per complir amb Veri*Factu, el programari de facturació ha d’incorporar mecanismes de seguretat que
-        impedeixin la manipulació dels registres. Cada factura ha de generar un fitxer amb una empremta
-        digital única, signat i enviat telemàticament. A més, el sistema ha de permetre l’enviament simultani
-        d’informació a l’Agència Tributària i al receptor de la factura, garantint la transparència de tot el
-        procés. També es requereix un registre d’esdeveniments que documenti qualsevol acció feta sobre les
-        dades. Les gestories han de verificar que els programes que utilitzen o recomanen als seus clients
-        estiguin degudament homologats i actualitzats.
-      </p>
-
-      <h2 className="mt-4">3. Avantatges de l’adopció de Veri*Factu</h2>
-      <p>
-        Tot i que pot semblar una obligació més, Veri*Factu ofereix beneficis tangibles. En primer lloc,
-        proporciona un major control sobre la facturació, reduint la possibilitat d’errors i duplicacions. En
-        segon lloc, facilita la preparació de declaracions fiscals, ja que la informació està centralitzada i
-        validada. A llarg termini, contribueix a una gestió més transparent i a una relació de confiança amb
-        l’Administració. Les gestories que s’anticipen a la normativa i ofereixen solucions basades en
-        Veri*Factu poden posicionar-se com a referents en compliment legal, generant un valor afegit per als
-        seus clients.
-      </p>
-
-      <h2 className="mt-4">4. Passos per implementar Veri*Factu a la gestoria</h2>
-      <p>
-        El procés d’adaptació comença amb l’elecció d’un programari compatible. És recomanable analitzar
-        diverses opcions i considerar aspectes com el suport tècnic, la facilitat d’ús i la integració amb altres
-        eines. Un cop triada l’eina, cal configurar-la correctament: definir els certificats digitals, establir els
-        camps obligatoris de les factures i assegurar-se que la comunicació amb l’Agència Tributària
-        funciona sense errors. També és important elaborar un protocol intern per gestionar incidències i
-        garantir còpies de seguretat. En molts casos, és útil realitzar una prova pilot amb un grup reduït de
-        clients abans de desplegar el sistema a tota la cartera.
-      </p>
-
-      <h2 className="mt-4">5. Formació i sensibilització dels clients</h2>
-      <p>
-        Un dels reptes més grans per a les gestories és aconseguir que els clients entenguin i acceptin els
-        canvis que suposa Veri*Factu. Cal organitzar sessions de formació i proporcionar materials clars que
-        expliquin com utilitzar el nou programari, com es generen les factures i què passa si es produeix un
-        error. La sensibilització també passa per destacar els avantatges: menys càrrega administrativa,
-        menys risc de sancions i una major confiança en la informació comptable. Les gestories que ofereixen
-        suport continu i responen ràpidament a les consultes aconsegueixen una transició molt més suau.
-      </p>
-
-      <h2 className="mt-4">6. Errors habituals i com evitar-los</h2>
-      <p>
-        Durant l’implementació de Veri*Factu poden sorgir diversos problemes. Un dels més comuns és no
-        verificar que el programari estigui correctament actualitzat amb les darreres especificacions
-        tècniques. També es produeixen errors en l’enviament de fitxers per manca de certificats vàlids o per
-        connexions inestables. A nivell organitzatiu, algunes empreses obliden formar adequadament el
-        personal, cosa que deriva en factures mal emeses. Per evitar aquests errors, és crucial mantenir un
-        calendari d’actualitzacions, disposar d’un servei tècnic fiable i establir procediments interns de
-        revisió abans d’enviar la informació a l’Agència Tributària.
-      </p>
-
-      <h2 className="mt-4">7. Veri*Factu i la transformació digital de les gestories</h2>
-      <p>
-        Adaptar-se a Veri*Factu no només és complir una normativa, sinó una oportunitat per impulsar la
-        digitalització de la gestoria. Els processos automatitzats i la integració amb altres eines permeten
-        oferir serveis més àgils i orientats al valor. Per exemple, es poden generar informes en temps real,
-        implementar portals per a clients o connectar el sistema amb plataformes de banca en línia. Aquest
-        enfocament incrementa la fidelització i atrau clients que busquen assessors moderns i proactius. A
-        més, les gestories digitalitzades estan millor preparades per adaptar-se a futures normatives sense
-        grans esforços addicionals.
-      </p>
-
-      <h2 className="mt-4">8. Cas pràctic: implantació gradual</h2>
-      <p>
-        Imaginem una gestoria amb cinquanta clients que decideix implementar Veri*Factu. El primer pas és
-        identificar els clients amb major volum de facturació i oferir-los una migració pilot. Durant aquesta
-        fase es detecten possibles incidències i s’ajusten els processos. Un cop validat el funcionament, la
-        gestoria programa sessions de formació agrupades i facilita vídeos explicatius. Al cap de tres mesos,
-        tots els clients utilitzen el nou sistema i s’han reduït un 30% els temps dedicats a tasques de
-        verificació. Aquest cas demostra que una implantació gradual, acompanyada de suport constant,
-        garanteix l’èxit del projecte.
-      </p>
-
-      <h2 className="mt-4">9. Recomanacions finals</h2>
-      <p>
-        Per afrontar Veri*Factu amb garanties, és recomanable mantenir una comunicació fluida amb els
-        proveïdors tecnològics i amb l’Agència Tributària. Participar en webinars, llegir les actualitzacions
-        oficials i formar part de comunitats professionals ajuda a estar al dia de possibles canvis. No oblidis
-        revisar periòdicament la configuració del programari i realitzar còpies de seguretat automàtiques. I, si
-        és possible, treballa amb partners tecnològics que entenguin les necessitats específiques de les
-        gestories i puguin oferir solucions a mida.
-      </p>
-
-      <h2 className="mt-4">Conclusió</h2>
-      <p>
-        Veri*Factu representa un repte per a moltes gestories, però també una oportunitat per professionalitzar
-        encara més el sector. Amb la preparació adequada, la formació de l’equip i les eines correctes, és
-        possible convertir aquesta obligació en un avantatge competitiu. Les gestories que abracin la
-        digitalització i incorporin Veri*Factu de manera proactiva demostraran als seus clients que estan
-        compromeses amb la transparència i l’eficiència. A JCT Agency oferim solucions tecnològiques que
-        simplifiquen aquest procés i t’ajudem a fer el pas cap a una gestió més moderna i segura.
-      </p>
-    </article>
-  </Layout>
-);
+  return (
+    <Layout>
+      <Helmet>
+        <title>{t('articles.verifactu.meta.title')}</title>
+        <meta
+          name="description"
+          content={t('articles.verifactu.meta.description')}
+        />
+      </Helmet>
+      <article className="container py-5">
+        <h1 className="mb-4">{t('articles.verifactu.title')}</h1>
+        {sections.map((section, index) => (
+          <div key={index} className="article-section">
+            {section.heading && <h2 className="mt-4">{section.heading}</h2>}
+            {section.paragraphs.map((paragraph, paragraphIndex) => (
+              <p key={paragraphIndex}>{paragraph}</p>
+            ))}
+          </div>
+        ))}
+      </article>
+    </Layout>
+  );
+};
 
 export default VerifactuGestoriesArticle;

--- a/src/components/components/contact.js
+++ b/src/components/components/contact.js
@@ -1,10 +1,16 @@
-import Layout from "../layouts/layout";
+import React, { useState } from "react";
 import emailjs from '@emailjs/browser';
-import React, {useState} from "react";
-import {Helmet} from "react-helmet";
+import { Helmet } from "react-helmet";
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
+import Layout from "../layouts/layout";
+import { DEFAULT_LANGUAGE } from '../../i18n';
 
 const Contact = () => {
+    const { t } = useTranslation();
+    const { lang } = useParams();
+    const currentLang = lang ?? DEFAULT_LANGUAGE;
 
     const [isFormSubmitted, setFormSubmitted] = useState(false);
     const [formFields, setFormFields] = useState({
@@ -16,13 +22,9 @@ const Contact = () => {
 
     const handleSubmit = (e) => {
         e.preventDefault();
-
-        // Configurar el servicio Email.js
         emailjs.sendForm('service_uaggcy8', 'template_88m2twe', e.target, 'PrtHsOGCYBrChfJU3')
-            .then((result) => {
-                console.log(result.text);
+            .then(() => {
                 setFormSubmitted(true);
-                // Vaciar los campos del formulario después del envío exitoso
                 setFormFields({
                     nombre: '',
                     empresa: '',
@@ -30,14 +32,12 @@ const Contact = () => {
                     mensaje: '',
                 });
             })
-            .catch((error) => {
-                console.log(error.text);
+            .catch(() => {
                 setFormSubmitted(false);
             });
     };
 
     const handleChange = (e) => {
-        // Actualizar el estado de los campos del formulario mientras el usuario escribe
         setFormFields({
             ...formFields,
             [e.target.name]: e.target.value,
@@ -47,44 +47,45 @@ const Contact = () => {
     return (
         <Layout>
             <Helmet>
-                <title>JCT Agency - Contacto</title>
-                <link rel="canonical" href="https://jctagency.com/contacto"/>
+                <title>{t('contact.meta.title')}</title>
+                <link rel="canonical" href={`https://jctagency.com/${currentLang}/contacto`} />
                 <meta
                     name="description"
-                    content="Contacta amb JCT Agency per rebre assessorament tecnològic i solucions digitals adaptades al teu negoci."
+                    content={t('contact.meta.description')}
                 />
             </Helmet>
 
             <div>
-                <section className={"container pt-5"}>
-                    <h1 className="text-center mb-4">Contacto</h1>
+                <section className="container pt-5">
+                    <h1 className="text-center mb-4">{t('contact.title')}</h1>
                     <p className="text-center text-muted">
-                        Estamos aquí para responder a tus preguntas y ayudarte en tu proyecto. Puedes contactar con nosotros mediante:
+                        {t('contact.intro')}
                     </p>
                     <div>
-                        <h2 className="mb-3">Información de contacto</h2>
+                        <h2 className="mb-3">{t('contact.info.title')}</h2>
                         <p>
-                            <strong>Direction:</strong> Online
+                            <strong>{t('contact.info.addressLabel')}</strong> {t('contact.info.addressValue')}
                         </p>
                         <p>
-                            <strong>Email:</strong> joan@jctagency.com
+                            <strong>{t('contact.info.emailLabel')}</strong> {t('contact.info.emailValue')}
                         </p>
                         <p>
-                            <strong>Phone:</strong> +34 633391411
+                            <strong>{t('contact.info.phoneLabel')}</strong> {t('contact.info.phoneValue')}
                         </p>
                     </div>
                     <div className="mt-4 pb-5">
-                        <h2 className="mb-3">Formulario de contacto</h2>
+                        <h2 className="mb-3">{t('contact.form.title')}</h2>
                         <form onSubmit={handleSubmit}>
                             <div className="mb-3">
                                 <label htmlFor="nombre" className="form-label">
-                                    Nombre:
+                                    {t('contact.form.nameLabel')}
                                 </label>
                                 <input
                                     type="text"
                                     className="form-control"
                                     id="nombre"
                                     name="nombre"
+                                    placeholder={t('contact.form.namePlaceholder')}
                                     value={formFields.nombre}
                                     onChange={handleChange}
                                     required
@@ -92,13 +93,14 @@ const Contact = () => {
                             </div>
                             <div className="mb-3">
                                 <label htmlFor="empresa" className="form-label">
-                                    Empresa:
+                                    {t('contact.form.companyLabel')}
                                 </label>
                                 <input
                                     type="text"
                                     className="form-control"
                                     id="empresa"
                                     name="empresa"
+                                    placeholder={t('contact.form.companyPlaceholder')}
                                     value={formFields.empresa}
                                     onChange={handleChange}
                                     required
@@ -106,13 +108,14 @@ const Contact = () => {
                             </div>
                             <div className="mb-3">
                                 <label htmlFor="email" className="form-label">
-                                    Email:
+                                    {t('contact.form.emailLabel')}
                                 </label>
                                 <input
                                     type="email"
                                     className="form-control"
                                     id="email"
                                     name="email"
+                                    placeholder={t('contact.form.emailPlaceholder')}
                                     value={formFields.email}
                                     onChange={handleChange}
                                     required
@@ -120,23 +123,24 @@ const Contact = () => {
                             </div>
                             <div className="mb-3">
                                 <label htmlFor="mensaje" className="form-label">
-                                    Mensaje:
+                                    {t('contact.form.messageLabel')}
                                 </label>
                                 <textarea
                                     className="form-control"
                                     id="mensaje"
                                     name="mensaje"
                                     rows="4"
+                                    placeholder={t('contact.form.messagePlaceholder')}
                                     value={formFields.mensaje}
                                     onChange={handleChange}
                                     required
                                 />
                             </div>
                             <button type="submit" className="btn btn-dark text-white">
-                                Enviar
+                                {t('contact.form.submit')}
                             </button>
                             {isFormSubmitted && (
-                                <p className="text-dark mt-3">¡Enviado!</p>
+                                <p className="text-dark mt-3">{t('contact.form.success')}</p>
                             )}
                         </form>
                     </div>

--- a/src/components/components/header.js
+++ b/src/components/components/header.js
@@ -1,25 +1,78 @@
 import React from 'react';
 import { Navbar, Nav, Container } from 'react-bootstrap';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import logoImage from '../img/LOGO JCTAGENCY.png';
+import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '../../i18n';
 
-const Header = () => (
-  <Navbar expand="lg" className="navbar-custom shadow-sm py-3" sticky="top">
-    <Container>
-      <Navbar.Brand href="/">
-        <img src={logoImage} alt="JCT Agency" className="rounded-circle" />
-      </Navbar.Brand>
-      <Navbar.Toggle aria-controls="main-navbar" />
-      <Navbar.Collapse id="main-navbar">
-        <Nav className="ms-auto">
-          <Nav.Link href="/">Home</Nav.Link>
-          <Nav.Link href="/avero">Avero</Nav.Link>
-          <Nav.Link href="/blog">Blog</Nav.Link>
-          <Nav.Link href="/pressupost">Pressupost</Nav.Link>
-          <Nav.Link href="/contacto">Contacto</Nav.Link>
-        </Nav>
-      </Navbar.Collapse>
-    </Container>
-  </Navbar>
-);
+const Header = () => {
+  const { t } = useTranslation();
+  const { lang: currentLang } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const activeLanguage = currentLang && SUPPORTED_LANGUAGES.includes(currentLang)
+    ? currentLang
+    : DEFAULT_LANGUAGE;
+
+  const buildPath = (path = '') => `/${activeLanguage}${path ? `/${path}` : ''}`;
+
+  const handleLanguageChange = (event) => {
+    const newLanguage = event.target.value;
+    if (newLanguage === activeLanguage) return;
+
+    const segments = location.pathname.split('/').filter(Boolean);
+    const remainder = segments.slice(1).join('/');
+    const nextPath = `/${newLanguage}${remainder ? `/${remainder}` : ''}`;
+    navigate(`${nextPath}${location.search}${location.hash}`);
+  };
+
+  return (
+    <Navbar expand="lg" className="navbar-custom shadow-sm py-3" sticky="top">
+      <Container>
+        <Navbar.Brand as={Link} to={buildPath('')}>
+          <img src={logoImage} alt={t('common.brandAlt')} className="rounded-circle" />
+        </Navbar.Brand>
+        <Navbar.Toggle aria-controls="main-navbar" />
+        <Navbar.Collapse id="main-navbar">
+          <Nav className="ms-auto align-items-lg-center">
+            <Nav.Link as={Link} to={buildPath('')}>
+              {t('navigation.home')}
+            </Nav.Link>
+            <Nav.Link as={Link} to={buildPath('avero')}>
+              {t('navigation.avero')}
+            </Nav.Link>
+            <Nav.Link as={Link} to={buildPath('blog')}>
+              {t('navigation.blog')}
+            </Nav.Link>
+            <Nav.Link as={Link} to={buildPath('pressupost')}>
+              {t('navigation.quote')}
+            </Nav.Link>
+            <Nav.Link as={Link} to={buildPath('contacto')}>
+              {t('navigation.contact')}
+            </Nav.Link>
+            <div className="ms-lg-3 mt-3 mt-lg-0">
+              <label htmlFor="language-selector" className="visually-hidden">
+                {t('language.label')}
+              </label>
+              <select
+                id="language-selector"
+                className="form-select form-select-sm"
+                value={activeLanguage}
+                onChange={handleLanguageChange}
+              >
+                {SUPPORTED_LANGUAGES.map((lng) => (
+                  <option key={lng} value={lng}>
+                    {t(`language.options.${lng}`)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </Nav>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  );
+};
 
 export default Header;

--- a/src/components/components/home.js
+++ b/src/components/components/home.js
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
-import Layout from "../layouts/layout";
 import { Helmet } from "react-helmet";
 import emailjs from "@emailjs/browser";
+import { Link, useParams } from 'react-router-dom';
+import { Trans, useTranslation } from 'react-i18next';
+
+import Layout from "../layouts/layout";
+import { DEFAULT_LANGUAGE } from '../../i18n';
 
 import heroImg from "../img/QUI SOM.png";
 import autonomIcon from "../img/AUTONOM.png";
 import pimesIcon from "../img/PYME.png";
 import gestoriesIcon from "../img/GESTORIA.png";
-
 
 import softwareImg from "../img/DESENVOLUPAMENT SOFTWARE.png";
 import consultoriesImg from "../img/CONSULTORIES.png";
@@ -22,11 +25,15 @@ import escalabilitatImg from "../img/ESCALABILITAT.png";
 import aliancesImg from "../img/ALIANÇES.png";
 import CTAIMAGE from "../img/CTA_HOME.png";
 
-
 import AjuntamentAldeaLogo from "../img/AJUNTAMENT.jpeg";
 import EGEALogo from "../img/EGEA.png";
 import GERCOLogo from "../img/gerco-serveis-integrals.png";
+
 const Home = () => {
+  const { t } = useTranslation();
+  const { lang } = useParams();
+  const currentLang = lang ?? DEFAULT_LANGUAGE;
+
   const [isFormSubmitted, setFormSubmitted] = useState(false);
   const [formFields, setFormFields] = useState({
     nombre: "",
@@ -50,41 +57,131 @@ const Home = () => {
     setFormFields({ ...formFields, [e.target.name]: e.target.value });
   };
 
+  const buildPath = (path = "") => `/${currentLang}${path ? `/${path}` : ""}`;
+
+  const clientSegments = [
+    {
+      icon: autonomIcon,
+      altKey: 'home.clients.items.autonomous.alt',
+      titleKey: 'home.clients.items.autonomous.title',
+      descriptionKey: 'home.clients.items.autonomous.description',
+    },
+    {
+      icon: pimesIcon,
+      altKey: 'home.clients.items.smes.alt',
+      titleKey: 'home.clients.items.smes.title',
+      descriptionKey: 'home.clients.items.smes.description',
+    },
+    {
+      icon: gestoriesIcon,
+      altKey: 'home.clients.items.accountants.alt',
+      titleKey: 'home.clients.items.accountants.title',
+      descriptionKey: 'home.clients.items.accountants.description',
+    },
+  ];
+
+  const services = [
+    {
+      icon: softwareImg,
+      altKey: 'home.services.items.software.alt',
+      titleKey: 'home.services.items.software.title',
+      descriptionKey: 'home.services.items.software.description',
+    },
+    {
+      icon: consultoriesImg,
+      altKey: 'home.services.items.consulting.alt',
+      titleKey: 'home.services.items.consulting.title',
+      descriptionKey: 'home.services.items.consulting.description',
+    },
+    {
+      icon: dissenyWebImg,
+      altKey: 'home.services.items.web.alt',
+      titleKey: 'home.services.items.web.title',
+      descriptionKey: 'home.services.items.web.description',
+    },
+    {
+      icon: suportImg,
+      altKey: 'home.services.items.support.alt',
+      titleKey: 'home.services.items.support.title',
+      descriptionKey: 'home.services.items.support.description',
+    },
+  ];
+
+  const benefits = [
+    {
+      icon: confiancaImg,
+      altKey: 'home.benefits.items.trust.alt',
+      titleKey: 'home.benefits.items.trust.title',
+      descriptionKey: 'home.benefits.items.trust.description',
+    },
+    {
+      icon: eficienciaImg,
+      altKey: 'home.benefits.items.efficiency.alt',
+      titleKey: 'home.benefits.items.efficiency.title',
+      descriptionKey: 'home.benefits.items.efficiency.description',
+    },
+    {
+      icon: escalabilitatImg,
+      altKey: 'home.benefits.items.scalability.alt',
+      titleKey: 'home.benefits.items.scalability.title',
+      descriptionKey: 'home.benefits.items.scalability.description',
+    },
+    {
+      icon: aliancesImg,
+      altKey: 'home.benefits.items.partnerships.alt',
+      titleKey: 'home.benefits.items.partnerships.title',
+      descriptionKey: 'home.benefits.items.partnerships.description',
+    },
+  ];
+
+  const values = [
+    { key: 'innovation' },
+    { key: 'simplicity' },
+    { key: 'compliance' },
+    { key: 'support' },
+  ];
+
+  const blogLinks = [
+    { path: 'blog/digitalitzar-pime', key: 'home.blog.links.digitalisation' },
+    { path: 'blog/verifactu-gestories', key: 'home.blog.links.verifactu' },
+    { path: 'blog/saas-vs-tradicional', key: 'home.blog.links.saas' },
+  ];
+
+  const contactDetails = [
+    { icon: '📧', key: 'home.contact.details.email' },
+    { icon: '📍', key: 'home.contact.details.location' },
+    { icon: '📱', key: 'home.contact.details.phone' },
+  ];
+
   return (
     <Layout>
       <Helmet>
-        <title>JCT Agency | Solucions digitals per fer créixer el teu negoci</title>
-        <meta
-          name="description"
-          content="Agència digital catalana especialista en software SaaS i solucions tecnològiques per a autònoms, PIMEs i gestories."
-        />
+        <title>{t('home.meta.title')}</title>
+        <meta name="description" content={t('home.meta.description')} />
       </Helmet>
 
       <div className="bg-white text-dark home-view">
-        {/* Hero */}
         <section className="py-5 bg-white" data-aos="fade-up">
           <div className="container">
             <div className="row align-items-center g-4 flex-column flex-md-row">
               <div className="col-md-6">
-                <h1>JCT Agency – Solucions digitals per a autònoms, PIMEs i gestories</h1>
+                <h1>{t('home.hero.title')}</h1>
                 <p>
-                  Som una agència tecnològica especialitzada en <strong>software SaaS</strong> i
-                  <strong> programari empresarial</strong> que simplifica la gestió i garanteix el
-                  <strong> compliment legal amb Veri*Factu</strong>.
+                  <Trans i18nKey="home.hero.description" components={{ strong: <strong /> }} />
                 </p>
                 <div className="d-flex gap-3 mt-3">
                   <a href="#serveis" className="btn btn-primary">
-                    Descobreix els nostres serveis
+                    {t('home.hero.ctaServices')}
                   </a>
                   <a href="#contacte" className="btn btn-outline-primary">
-                    Parla amb nosaltres
+                    {t('home.hero.ctaContact')}
                   </a>
                 </div>
               </div>
               <div className="col-md-6 text-center">
                 <img
                   src={heroImg}
-                  alt="Handshake"
+                  alt={t('home.hero.imageAlt')}
                   className="img-fluid"
                   style={{ maxWidth: "300px" }}
                 />
@@ -93,155 +190,91 @@ const Home = () => {
           </div>
         </section>
 
-        {/* Clients */}
         <section id="clients" className="py-5 bg-light" data-aos="fade-up">
           <div className="container">
-            <h2 className="text-center mb-4">Ajudem empreses com la teva</h2>
+            <h2 className="text-center mb-4">{t('home.clients.title')}</h2>
             <p className="text-center">
-              El nostre software està pensat per a <strong>autònoms</strong>, <strong>PIMEs</strong> i
-              <strong> gestories</strong> que volen digitalitzar-se sense complicacions.
+              <Trans i18nKey="home.clients.description" components={{ strong: <strong /> }} />
             </p>
             <div className="row mt-4">
-              <div className="col-md-4 text-center mb-4">
-                <img src={autonomIcon} alt="Autònoms" style={{ width: "60px" }} className="mb-3" />
-                <h5>Autònoms</h5>
-                <p>Solucions adaptades als professionals independents.</p>
-              </div>
-              <div className="col-md-4 text-center mb-4">
-                <img src={pimesIcon} alt="PIMEs" style={{ width: "60px" }} className="mb-3" />
-                <h5>PIMEs</h5>
-                <p>Eines modernes per optimitzar la gestió empresarial.</p>
-              </div>
-              <div className="col-md-4 text-center mb-4">
-                <img
-                  src={gestoriesIcon}
-                  alt="Gestories"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h5>Gestories</h5>
-                <p>Programari que facilita nous serveis digitals als clients.</p>
-              </div>
+              {clientSegments.map(({ icon, altKey, titleKey, descriptionKey }) => (
+                <div className="col-md-4 text-center mb-4" key={titleKey}>
+                  <img src={icon} alt={t(altKey)} style={{ width: "60px" }} className="mb-3" />
+                  <h5>{t(titleKey)}</h5>
+                  <p><Trans i18nKey={descriptionKey} components={{ strong: <strong /> }} /></p>
+                </div>
+              ))}
             </div>
           </div>
         </section>
 
-        {/* Serveis */}
         <section id="serveis" className="py-5 bg-white" data-aos="fade-up">
           <div className="container">
-            <h2 className="text-center mb-4">Els nostres serveis</h2>
-            <p className="text-center mb-5">
-              A JCT Agency oferim serveis digitals per impulsar el creixement i l’eficiència del teu
-              negoci.
-            </p>
+            <h2 className="text-center mb-4">{t('home.services.title')}</h2>
+            <p className="text-center mb-5">{t('home.services.description')}</p>
             <div className="row row-cols-1 row-cols-md-2 g-4">
-              <div className="col text-center">
-                <img
-                  src={softwareImg}
-                  alt="Desenvolupament de software empresarial"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h3>Desenvolupament de software empresarial</h3>
-                <p>
-                  Creem <strong>programari propi</strong>, <strong>solucions SaaS</strong> i
-                  <strong> integracions amb serveis externs</strong> perquè la teva empresa treballi amb
-                  eines modernes i segures.
-                </p>
-                <a href="#contacte" className="btn btn-link">
-                  Més informació
-                </a>
-              </div>
-              <div className="col text-center">
-                <img
-                  src={consultoriesImg}
-                  alt="Consultoria tecnològica i legal"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h3>Consultoria tecnològica i legal</h3>
-                <p>
-                  T’assessorem en <strong>noves normatives</strong>, <strong>estratègies de digitalització</strong> i
-                  compliment amb <strong>Veri*Factu</strong>, perquè estiguis sempre a l’avantguarda.
-                </p>
-                <a href="#contacte" className="btn btn-link">
-                  Més informació
-                </a>
-              </div>
-              <div className="col text-center">
-                <img
-                  src={dissenyWebImg}
-                  alt="Disseny i manteniment web"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h3>Disseny i manteniment web</h3>
-                <p>
-                  Creem i gestionem <strong>webs corporatives</strong> modernes, amb <strong>manteniment constant</strong>,
-                  actualitzacions i seguretat garantida.
-                </p>
-                <a href="#contacte" className="btn btn-link">
-                  Més informació
-                </a>
-              </div>
-              <div className="col text-center">
-                <img src={suportImg} alt="Suport continuat" style={{ width: "60px" }} className="mb-3" />
-                <h3>Suport continuat</h3>
-                <p>
-                  Ens involucrem en els teus projectes amb <strong>atenció propera</strong> i
-                  <strong> evolució constant del software</strong>, perquè el teu negoci mai s’aturi.
-                </p>
-                <a href="#contacte" className="btn btn-link">
-                  Més informació
-                </a>
-              </div>
+              {services.map(({ icon, altKey, titleKey, descriptionKey }) => (
+                <div className="col text-center" key={titleKey}>
+                  <img
+                    src={icon}
+                    alt={t(altKey)}
+                    style={{ width: "60px" }}
+                    className="mb-3"
+                  />
+                  <h3>{t(titleKey)}</h3>
+                  <p>
+                    <Trans i18nKey={descriptionKey} components={{ strong: <strong /> }} />
+                  </p>
+                  <a href="#contacte" className="btn btn-link">
+                    {t('home.services.learnMore')}
+                  </a>
+                </div>
+              ))}
             </div>
           </div>
         </section>
 
-        {/* Avero */}
         <section id="avero" className="py-5 bg-light" data-aos="fade-up">
           <div className="container">
             <div className="row align-items-center g-4">
               <div className="col-md-6">
-                <h2>Avero – Facturació moderna i segura</h2>
+                <h2>{t('home.avero.title')}</h2>
                 <p>
-                  <strong>Avero</strong> és el nostre <strong>software SaaS de facturació</strong>, pensat per a
-                  <strong> autònoms i PIMEs</strong>. Et permet gestionar <strong>factures, pressupostos, albarans i TPV</strong>
-                  de forma simple, amb <strong>enviament automàtic a l’AEAT</strong> i total compliment legal amb
-                  <strong> Veri*Factu</strong>.
+                  <Trans i18nKey="home.avero.description" components={{ strong: <strong /> }} />
                 </p>
                 <ul>
-                  <li>Facturació electrònica completa i segura</li>
-                  <li>Pressupostos, albarans i TPV integrats</li>
-                  <li>Gestió de clients i productes</li>
-                  <li>Compliment normatiu amb Veri*Factu</li>
+                  {['pointOne', 'pointTwo', 'pointThree', 'pointFour'].map((itemKey) => (
+                    <li key={itemKey}>{t(`home.avero.list.${itemKey}`)}</li>
+                  ))}
                 </ul>
                 <div className="d-flex gap-3 mt-3">
-                  <a href="/avero" className="btn btn-primary">Coneix Avero</a>
-                  <a href="https://avero.jctagency.com" className="btn btn-outline-primary">Prova Avero gratis</a>
+                  <Link to={buildPath('avero')} className="btn btn-primary">
+                    {t('home.avero.primaryCta')}
+                  </Link>
+                  <a href="https://avero.jctagency.com" className="btn btn-outline-primary">
+                    {t('home.avero.secondaryCta')}
+                  </a>
                 </div>
               </div>
               <div className="col-md-6 text-center">
-                <img src={AveroLogo} alt="Avero" className="img-fluid" style={{ maxWidth: "300px" }} />
+                <img src={AveroLogo} alt={t('home.avero.imageAlt')} className="img-fluid" style={{ maxWidth: "300px" }} />
               </div>
             </div>
           </div>
         </section>
 
-        {/* CTA custom software */}
         <section id="cta-programari" className="py-5 text-center bg-white" data-aos="fade-up">
           <div className="container">
             <div className="row align-items-center g-4">
               <div className="col-md-6">
-                <h2 className="mb-3">Necessites un programa específic per la teva empresa?</h2>
-                <p>Vols estalviar temps optimitzant tasques amb un programari a mida!</p>
-                <a href="#contacte" className="btn btn-primary mt-3">Contacta'ns</a>
+                <h2 className="mb-3">{t('home.customCta.title')}</h2>
+                <p>{t('home.customCta.description')}</p>
+                <a href="#contacte" className="btn btn-primary mt-3">{t('home.customCta.button')}</a>
               </div>
               <div className="col-md-6 text-center">
                 <img
                   src={CTAIMAGE}
-                  alt="Programari a mida"
+                  alt={t('home.customCta.imageAlt')}
                   className="img-fluid"
                   style={{ maxWidth: "300px" }}
                 />
@@ -250,168 +283,117 @@ const Home = () => {
           </div>
         </section>
 
-        {/* Beneficis */}
         <section id="beneficis" className="py-5 bg-light" data-aos="fade-up">
           <div className="container">
-            <h2 className="text-center mb-4">Què aportem als nostres clients</h2>
+            <h2 className="text-center mb-4">{t('home.benefits.title')}</h2>
             <div className="row row-cols-2 row-cols-md-4 g-4">
-              <div className="col text-center">
-                <img src={confiancaImg} alt="Confiança" style={{ width: "60px" }} className="mb-3" />
-                <h3>Confiança</h3>
-                <p>
-                  Treballem perquè compleixis amb la normativa sense maldecaps, amb <strong>solucions fiables i segures</strong>.
-                </p>
-              </div>
-              <div className="col text-center">
-                <img src={eficienciaImg} alt="Eficiència" style={{ width: "60px" }} className="mb-3" />
-                <h3>Eficiència</h3>
-                <p>
-                  Optimitza el teu temps amb <strong>processos simplificats</strong> i un software intuïtiu.
-                </p>
-              </div>
-              <div className="col text-center">
-                <img
-                  src={escalabilitatImg}
-                  alt="Escalabilitat"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h3>Escalabilitat</h3>
-                <p>Les nostres solucions creixen amb el teu negoci, adaptant-se a noves necessitats.</p>
-              </div>
-              <div className="col text-center">
-                <img
-                  src={aliancesImg}
-                  alt="Aliances estratègiques"
-                  style={{ width: "60px" }}
-                  className="mb-3"
-                />
-                <h3>Aliances estratègiques</h3>
-                <p>
-                  Oferim a les <strong>gestories</strong> eines que obren <strong>nous canals d’ingressos</strong> i milloren el servei als seus clients.
-                </p>
-              </div>
+              {benefits.map(({ icon, altKey, titleKey, descriptionKey }) => (
+                <div className="col text-center" key={titleKey}>
+                  <img src={icon} alt={t(altKey)} style={{ width: "60px" }} className="mb-3" />
+                  <h3>{t(titleKey)}</h3>
+                  <p>
+                    <Trans i18nKey={descriptionKey} components={{ strong: <strong /> }} />
+                  </p>
+                </div>
+              ))}
             </div>
           </div>
         </section>
 
-        {/* Clients que confien */}
         <section id="clients-validen" className="py-5 bg-white" data-aos="fade-up">
           <div className="container">
-            <h2 className="text-center mb-4">Clients que confien en nosaltres</h2>
+            <h2 className="text-center mb-4">{t('home.testimonials.title')}</h2>
             <div className="row text-center align-items-center g-4">
               <div className="col-md-4">
                 <div className="mb-3" style={{ height: "80px" }}>
                   <img
                     src={AjuntamentAldeaLogo}
-                    alt="Ajuntament de L'Aldea"
+                    alt={t('home.testimonials.items.ajuntament.alt')}
                     className="img-fluid h-100"
                     style={{ objectFit: "contain" }}
                   />
                 </div>
-                <p>Ajuntament de L'Aldea</p>
+                <p>{t('home.testimonials.items.ajuntament.name')}</p>
               </div>
               <div className="col-md-4">
                 <div className="mb-3" style={{ height: "80px" }}>
                   <img
                     src={EGEALogo}
-                    alt="EGEA Arquitectura"
+                    alt={t('home.testimonials.items.egea.alt')}
                     className="img-fluid h-100"
                     style={{ objectFit: "contain" }}
                   />
                 </div>
-                <p>EGEA Arquitectura</p>
+                <p>{t('home.testimonials.items.egea.name')}</p>
               </div>
               <div className="col-md-4">
                 <div className="mb-3" style={{ height: "80px" }}>
                   <img
                     src={GERCOLogo}
-                    alt="GERCO Serveis Integrals"
+                    alt={t('home.testimonials.items.gerco.alt')}
                     className="img-fluid h-100"
                     style={{ objectFit: "contain" }}
                   />
                 </div>
-                <p>GERCO Serveis Integrals</p>
+                <p>{t('home.testimonials.items.gerco.name')}</p>
               </div>
             </div>
           </div>
         </section>
 
-        {/* Valors */}
         <section id="valors" className="py-5 bg-light" data-aos="fade-up">
           <div className="container">
-            <h2 className="text-center mb-4">Els nostres valors</h2>
+            <h2 className="text-center mb-4">{t('home.values.title')}</h2>
             <p className="text-center">
-              A JCT Agency treballem amb una filosofia clara: oferir <strong>innovació, simplicitat, seguretat i proximitat</strong>.
+              <Trans i18nKey="home.values.description" components={{ strong: <strong /> }} />
             </p>
             <ul className="list-unstyled row g-4 mt-4">
-              <li className="col-md-3 d-flex align-items-start">
-                <span className="text-primary me-2">•</span>
-                <span>
-                  <strong>Innovació</strong> – sempre a l’avantguarda tecnològica i legal.
-                </span>
-              </li>
-              <li className="col-md-3 d-flex align-items-start">
-                <span className="text-primary me-2">•</span>
-                <span>
-                  <strong>Simplicitat</strong> – software intuïtiu que facilita el treball, no el complica.
-                </span>
-              </li>
-              <li className="col-md-3 d-flex align-items-start">
-                <span className="text-primary me-2">•</span>
-                <span>
-                  <strong>Compliment legal i seguretat</strong> – desenvolupem sistemes totalment adaptats a Veri*Factu i altres normatives.
-                </span>
-              </li>
-              <li className="col-md-3 d-flex align-items-start">
-                <span className="text-primary me-2">•</span>
-                <span>
-                  <strong>Proximitat i suport</strong> – ens involucrem en cada projecte com si fos nostre.
-                </span>
-              </li>
+              {values.map(({ key }) => (
+                <li className="col-md-3 d-flex align-items-start" key={key}>
+                  <span className="text-primary me-2">•</span>
+                  <span>
+                    <Trans i18nKey={`home.values.items.${key}`} components={{ strong: <strong /> }} />
+                  </span>
+                </li>
+              ))}
             </ul>
           </div>
         </section>
 
-        {/* Blog / Recursos */}
         <section id="blog" className="py-5 bg-white" data-aos="fade-up">
           <div className="container">
-            <h2 className="text-center mb-4">Recursos i guies útils</h2>
+            <h2 className="text-center mb-4">{t('home.blog.title')}</h2>
             <ul className="list-unstyled">
-              <li>
-                <a href="/blog/digitalitzar-pime">Com digitalitzar la gestió d’una PIME en 5 passos</a>
-              </li>
-              <li>
-                <a href="/blog/verifactu-gestories">Guia pràctica per a gestories sobre Veri*Factu</a>
-              </li>
-              <li>
-                <a href="/blog/saas-vs-tradicional">Per què un SaaS és millor que un software tradicional?</a>
-              </li>
+              {blogLinks.map(({ path, key }) => (
+                <li key={key}>
+                  <Link to={buildPath(path)}>{t(key)}</Link>
+                </li>
+              ))}
             </ul>
           </div>
         </section>
 
-        {/* Pressupost */}
         <section id="pressupost" className="py-5 bg-light" data-aos="fade-up">
           <div className="container text-center">
-            <h2 className="mb-4">Vols una estimació del teu projecte?</h2>
-            <p>Utilitza la nostra calculadora per conèixer el pressupost aproximat.</p>
-            <a href="/pressupost" className="btn btn-outline-primary">Calcula el teu pressupost</a>
+            <h2 className="mb-4">{t('home.quoteSection.title')}</h2>
+            <p>{t('home.quoteSection.description')}</p>
+            <Link to={buildPath('pressupost')} className="btn btn-outline-primary">
+              {t('home.quoteSection.button')}
+            </Link>
           </div>
         </section>
 
-        {/* Contacte */}
         <section id="contacte" className="py-5 bg-white" data-aos="fade-up">
           <div className="container">
             <div className="row g-4">
               <div className="col-md-6">
-                <h2>Parlem del teu projecte?</h2>
-                <p>Si busques un partner tecnològic per digitalitzar la teva empresa, contacta amb nosaltres.</p>
+                <h2>{t('home.contact.title')}</h2>
+                <p>{t('home.contact.description')}</p>
                 <form onSubmit={handleSubmit}>
                   <input
                     type="text"
                     name="nombre"
-                    placeholder="Nom i cognoms"
+                    placeholder={t('home.contact.form.name')}
                     className="form-control mb-3"
                     value={formFields.nombre}
                     onChange={handleChange}
@@ -420,7 +402,7 @@ const Home = () => {
                   <input
                     type="text"
                     name="empresa"
-                    placeholder="Empresa"
+                    placeholder={t('home.contact.form.company')}
                     className="form-control mb-3"
                     value={formFields.empresa}
                     onChange={handleChange}
@@ -428,7 +410,7 @@ const Home = () => {
                   <input
                     type="email"
                     name="email"
-                    placeholder="Email"
+                    placeholder={t('home.contact.form.email')}
                     className="form-control mb-3"
                     value={formFields.email}
                     onChange={handleChange}
@@ -436,7 +418,7 @@ const Home = () => {
                   />
                   <textarea
                     name="mensaje"
-                    placeholder="Missatge"
+                    placeholder={t('home.contact.form.message')}
                     className="form-control mb-3"
                     rows="4"
                     value={formFields.mensaje}
@@ -444,21 +426,17 @@ const Home = () => {
                     required
                   ></textarea>
                   <button type="submit" className="btn btn-primary">
-                    Enviar missatge
+                    {t('home.contact.form.submit')}
                   </button>
-                  {isFormSubmitted && <p className="mt-3">¡Missatge enviat!</p>}
+                  {isFormSubmitted && <p className="mt-3">{t('home.contact.form.success')}</p>}
                 </form>
               </div>
               <div className="col-md-6">
-                <p>
-                  <strong>📧</strong> info@jctagency.com
-                </p>
-                <p>
-                  <strong>📍</strong> Tarragona (Catalunya)
-                </p>
-                <p>
-                  <strong>📱</strong> 633 391 411
-                </p>
+                {contactDetails.map(({ icon, key }) => (
+                  <p key={key}>
+                    <strong>{icon}</strong> {t(key)}
+                  </p>
+                ))}
               </div>
             </div>
           </div>
@@ -469,4 +447,3 @@ const Home = () => {
 };
 
 export default Home;
-

--- a/src/components/components/pressupost.js
+++ b/src/components/components/pressupost.js
@@ -1,10 +1,17 @@
 import React, { useState } from 'react';
-import Layout from '../layouts/layout';
 import { Helmet } from 'react-helmet';
+import { Link, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import emailjs from '@emailjs/browser';
-import { Link } from 'react-router-dom';
+
+import Layout from '../layouts/layout';
+import { DEFAULT_LANGUAGE } from '../../i18n';
 
 const Pressupost = () => {
+  const { t } = useTranslation();
+  const { lang } = useParams();
+  const currentLang = lang ?? DEFAULT_LANGUAGE;
+
   const [service, setService] = useState('');
   const initialForm = {
     nombre: '',
@@ -15,11 +22,13 @@ const Pressupost = () => {
     modules: '1-2',
     cloud: false,
     platforms: 'one',
-    auth: false
+    auth: false,
   };
   const [formData, setFormData] = useState(initialForm);
   const [price, setPrice] = useState(null);
   const [sent, setSent] = useState(false);
+
+  const buildPath = (path = '') => `/${currentLang}${path ? `/${path}` : ''}`;
 
   const handleServiceChange = (e) => {
     setService(e.target.value);
@@ -57,14 +66,25 @@ const Pressupost = () => {
     const estimated = calculatePrice();
     setPrice(estimated);
     const { nombre, empresa, email, ...rest } = formData;
-    const mensaje = `Servei: ${service}\nDetalls: ${JSON.stringify(rest)}\nPressupost: ${estimated}€`;
+    const serviceLabel = service ? t(`pressupost.form.projectType.values.${service}`) : '';
+    const mensaje = t('pressupost.emailMessage', {
+      service: serviceLabel,
+      details: JSON.stringify(rest),
+      price: estimated,
+    });
+
     emailjs
-      .send('service_uaggcy8', 'template_yav8r89', {
-        nombre,
-        empresa,
-        email,
-        mensaje
-      }, 'PrtHsOGCYBrChfJU3')
+      .send(
+        'service_uaggcy8',
+        'template_yav8r89',
+        {
+          nombre,
+          empresa,
+          email,
+          mensaje,
+        },
+        'PrtHsOGCYBrChfJU3'
+      )
       .then(() => {
         setSent(true);
         setFormData(initialForm);
@@ -75,18 +95,18 @@ const Pressupost = () => {
   return (
     <Layout>
       <Helmet>
-        <title>Calcula el teu pressupost | JCT Agency</title>
-        <meta name="description" content="Calcula de manera orientativa el cost del teu projecte digital." />
+        <title>{t('pressupost.meta.title')}</title>
+        <meta name="description" content={t('pressupost.meta.description')} />
       </Helmet>
       <div className="container py-5">
-        <h1 className="mb-4 text-center">Calculadora de pressupost</h1>
+        <h1 className="mb-4 text-center">{t('pressupost.title')}</h1>
         <div className="mb-4">
-          <label className="form-label">Tipus de projecte</label>
+          <label className="form-label">{t('pressupost.form.projectType.label')}</label>
           <select className="form-select" value={service} onChange={handleServiceChange} required>
-            <option value="">Selecciona una opció</option>
-            <option value="web">Pàgina web</option>
-            <option value="software">Programa a mida</option>
-            <option value="app">App mòbil</option>
+            <option value="">{t('pressupost.form.projectType.placeholder')}</option>
+            <option value="web">{t('pressupost.form.projectType.options.web')}</option>
+            <option value="software">{t('pressupost.form.projectType.options.software')}</option>
+            <option value="app">{t('pressupost.form.projectType.options.app')}</option>
           </select>
         </div>
 
@@ -95,16 +115,16 @@ const Pressupost = () => {
             {service === 'web' && (
               <>
                 <div className="mb-3">
-                  <label className="form-label">Nombre de pàgines</label>
+                  <label className="form-label">{t('pressupost.form.web.pagesLabel')}</label>
                   <select name="pages" className="form-select" value={formData.pages} onChange={handleChange}>
-                    <option value="1-5">1-5</option>
-                    <option value="6-10">6-10</option>
-                    <option value="11+">Més de 10</option>
+                    <option value="1-5">{t('pressupost.form.web.pages.options.basic')}</option>
+                    <option value="6-10">{t('pressupost.form.web.pages.options.medium')}</option>
+                    <option value="11+">{t('pressupost.form.web.pages.options.advanced')}</option>
                   </select>
                 </div>
                 <div className="form-check mb-3">
                   <input className="form-check-input" type="checkbox" id="ecommerce" name="ecommerce" checked={formData.ecommerce} onChange={handleChange} />
-                  <label className="form-check-label" htmlFor="ecommerce">Incloure e-commerce</label>
+                  <label className="form-check-label" htmlFor="ecommerce">{t('pressupost.form.web.ecommerce')}</label>
                 </div>
               </>
             )}
@@ -112,16 +132,16 @@ const Pressupost = () => {
             {service === 'software' && (
               <>
                 <div className="mb-3">
-                  <label className="form-label">Nombre de mòduls</label>
+                  <label className="form-label">{t('pressupost.form.software.modulesLabel')}</label>
                   <select name="modules" className="form-select" value={formData.modules} onChange={handleChange}>
-                    <option value="1-2">1-2</option>
-                    <option value="3-5">3-5</option>
-                    <option value="6+">6 o més</option>
+                    <option value="1-2">{t('pressupost.form.software.modules.options.basic')}</option>
+                    <option value="3-5">{t('pressupost.form.software.modules.options.medium')}</option>
+                    <option value="6+">{t('pressupost.form.software.modules.options.advanced')}</option>
                   </select>
                 </div>
                 <div className="form-check mb-3">
                   <input className="form-check-input" type="checkbox" id="cloud" name="cloud" checked={formData.cloud} onChange={handleChange} />
-                  <label className="form-check-label" htmlFor="cloud">Integració al núvol</label>
+                  <label className="form-check-label" htmlFor="cloud">{t('pressupost.form.software.cloud')}</label>
                 </div>
               </>
             )}
@@ -129,44 +149,44 @@ const Pressupost = () => {
             {service === 'app' && (
               <>
                 <div className="mb-3">
-                  <label className="form-label">Plataformes</label>
+                  <label className="form-label">{t('pressupost.form.app.platformsLabel')}</label>
                   <select name="platforms" className="form-select" value={formData.platforms} onChange={handleChange}>
-                    <option value="one">iOS o Android</option>
-                    <option value="both">iOS i Android</option>
+                    <option value="one">{t('pressupost.form.app.platforms.options.single')}</option>
+                    <option value="both">{t('pressupost.form.app.platforms.options.multiple')}</option>
                   </select>
                 </div>
                 <div className="form-check mb-3">
                   <input className="form-check-input" type="checkbox" id="auth" name="auth" checked={formData.auth} onChange={handleChange} />
-                  <label className="form-check-label" htmlFor="auth">Autenticació d'usuaris</label>
+                  <label className="form-check-label" htmlFor="auth">{t('pressupost.form.app.auth')}</label>
                 </div>
               </>
             )}
 
             <div className="mb-3">
-              <label className="form-label">Nom</label>
+              <label className="form-label">{t('pressupost.form.name')}</label>
               <input type="text" name="nombre" className="form-control" value={formData.nombre} onChange={handleChange} required />
             </div>
             <div className="mb-3">
-              <label className="form-label">Empresa</label>
+              <label className="form-label">{t('pressupost.form.company')}</label>
               <input type="text" name="empresa" className="form-control" value={formData.empresa} onChange={handleChange} />
             </div>
             <div className="mb-3">
-              <label className="form-label">Email</label>
+              <label className="form-label">{t('pressupost.form.email')}</label>
               <input type="email" name="email" className="form-control" value={formData.email} onChange={handleChange} required />
             </div>
-            <button type="submit" className="btn btn-primary">Calcula pressupost</button>
-            {sent && <p className="mt-3">Dades enviades correctament.</p>}
+            <button type="submit" className="btn btn-primary">{t('pressupost.form.submit')}</button>
+            {sent && <p className="mt-3">{t('pressupost.form.success')}</p>}
           </form>
         )}
 
         {price !== null && (
           <div className="mt-4 text-center">
             <div className="alert alert-info" role="alert">
-              Pressupost estimat: {price}€
+              {t('pressupost.result.estimated', { price })}
             </div>
-            <p>Si el pressupost et quadra</p>
-            <Link to="/contacto" className="btn btn-success">
-              Contacta
+            <p>{t('pressupost.result.nextStep')}</p>
+            <Link to={buildPath('contacto')} className="btn btn-success">
+              {t('pressupost.result.contactCta')}
             </Link>
           </div>
         )}
@@ -176,4 +196,3 @@ const Pressupost = () => {
 };
 
 export default Pressupost;
-

--- a/src/components/layouts/layout.js
+++ b/src/components/layouts/layout.js
@@ -1,24 +1,29 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Header from '../components/header';
 import logoImage from '../img/LOGO JCTAGENCY.png';
 
-const Layout = ({ children }) => (
-  <>
-    <Header />
-    <main>{children}</main>
-    <footer className="footer-custom py-4 mt-auto">
-      <div className="container d-flex flex-column flex-md-row align-items-center justify-content-between">
-        <div className="mb-3 mb-md-0">
-          <img src={logoImage} alt="Logo JCT Agency" className="rounded-circle" />
+const Layout = ({ children }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+      <footer className="footer-custom py-4 mt-auto">
+        <div className="container d-flex flex-column flex-md-row align-items-center justify-content-between">
+          <div className="mb-3 mb-md-0">
+            <img src={logoImage} alt={t('layout.footer.logoAlt')} className="rounded-circle" />
+          </div>
+          <div className="text-center text-md-end">
+            <p className="mb-1">{t('layout.footer.copy')}</p>
+            <p className="mb-1">{t('layout.footer.contact')}</p>
+            <p className="mb-0">{t('layout.footer.follow')}</p>
+          </div>
         </div>
-        <div className="text-center text-md-end">
-          <p className="mb-1">© 2024 JCT Agency – Solucions digitals i software SaaS.</p>
-          <p className="mb-1">Email: joan@jctagency.com | Telèfon: 633 391 411</p>
-          <p className="mb-0">Segueix-nos a LinkedIn</p>
-        </div>
-      </div>
-    </footer>
-  </>
-);
+      </footer>
+    </>
+  );
+};
 
 export default Layout;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,46 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import translationCA from './locales/ca.json';
+import translationES from './locales/es.json';
+
+export const SUPPORTED_LANGUAGES = ['ca', 'es'];
+export const DEFAULT_LANGUAGE = 'ca';
+const STORAGE_KEY = 'preferredLanguage';
+
+const getInitialLanguage = () => {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && SUPPORTED_LANGUAGES.includes(stored)) {
+      return stored;
+    }
+  }
+  return DEFAULT_LANGUAGE;
+};
+
+const resources = {
+  ca: { translation: translationCA },
+  es: { translation: translationES },
+};
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources,
+    lng: getInitialLanguage(),
+    fallbackLng: DEFAULT_LANGUAGE,
+    interpolation: {
+      escapeValue: false,
+    },
+    returnObjects: true,
+  });
+
+if (typeof window !== 'undefined') {
+  i18n.on('languageChanged', (lng) => {
+    if (SUPPORTED_LANGUAGES.includes(lng)) {
+      window.localStorage.setItem(STORAGE_KEY, lng);
+    }
+  });
+}
+
+export default i18n;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import emailjs from '@emailjs/browser';
+import './i18n';
 
 emailjs.init('PrtHsOGCYBrChfJU3');
 

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -1,0 +1,700 @@
+{
+  "common": {
+    "brandAlt": "JCT Agency"
+  },
+  "navigation": {
+    "home": "Inici",
+    "avero": "Avero",
+    "blog": "Blog",
+    "quote": "Pressupost",
+    "contact": "Contacte"
+  },
+  "language": {
+    "label": "Selecciona idioma",
+    "options": {
+      "ca": "Català",
+      "es": "Castellano"
+    }
+  },
+  "layout": {
+    "footer": {
+      "logoAlt": "Logo JCT Agency",
+      "copy": "© 2024 JCT Agency – Solucions digitals i software SaaS.",
+      "contact": "Email: joan@jctagency.com | Telèfon: 633 391 411",
+      "follow": "Segueix-nos a LinkedIn"
+    }
+  },
+  "home": {
+    "meta": {
+      "title": "JCT Agency | Solucions digitals per fer créixer el teu negoci",
+      "description": "Agència digital catalana especialista en software SaaS i solucions tecnològiques per a autònoms, PIMEs i gestories."
+    },
+    "hero": {
+      "title": "JCT Agency – Solucions digitals per a autònoms, PIMEs i gestories",
+      "description": "Som una agència tecnològica especialitzada en <strong>software SaaS</strong> i <strong>programari empresarial</strong> que simplifica la gestió i garanteix el <strong>compliment legal amb Veri*Factu</strong>.",
+      "ctaServices": "Descobreix els nostres serveis",
+      "ctaContact": "Parla amb nosaltres",
+      "imageAlt": "Equip de JCT Agency"
+    },
+    "clients": {
+      "title": "Ajudem empreses com la teva",
+      "description": "El nostre software està pensat per a <strong>autònoms</strong>, <strong>PIMEs</strong> i <strong>gestories</strong> que volen digitalitzar-se sense complicacions.",
+      "items": {
+        "autonomous": {
+          "alt": "Autònoms",
+          "title": "Autònoms",
+          "description": "Solucions adaptades als professionals independents."
+        },
+        "smes": {
+          "alt": "PIMEs",
+          "title": "PIMEs",
+          "description": "Eines modernes per optimitzar la gestió empresarial."
+        },
+        "accountants": {
+          "alt": "Gestories",
+          "title": "Gestories",
+          "description": "Programari que facilita nous serveis digitals als clients."
+        }
+      }
+    },
+    "services": {
+      "title": "Els nostres serveis",
+      "description": "A JCT Agency oferim serveis digitals per impulsar el creixement i l’eficiència del teu negoci.",
+      "learnMore": "Més informació",
+      "items": {
+        "software": {
+          "alt": "Desenvolupament de software empresarial",
+          "title": "Desenvolupament de software empresarial",
+          "description": "Creem <strong>programari propi</strong>, <strong>solucions SaaS</strong> i <strong>integracions amb serveis externs</strong> perquè la teva empresa treballi amb eines modernes i segures."
+        },
+        "consulting": {
+          "alt": "Consultoria tecnològica i legal",
+          "title": "Consultoria tecnològica i legal",
+          "description": "T’assessorem en <strong>noves normatives</strong>, <strong>estratègies de digitalització</strong> i compliment amb <strong>Veri*Factu</strong>, perquè estiguis sempre a l’avantguarda."
+        },
+        "web": {
+          "alt": "Disseny i manteniment web",
+          "title": "Disseny i manteniment web",
+          "description": "Creem i gestionem <strong>webs corporatives</strong> modernes, amb <strong>manteniment constant</strong>, actualitzacions i seguretat garantida."
+        },
+        "support": {
+          "alt": "Suport continuat",
+          "title": "Suport continuat",
+          "description": "Ens involucrem en els teus projectes amb <strong>atenció propera</strong> i <strong>evolució constant del software</strong>, perquè el teu negoci mai s’aturi."
+        }
+      }
+    },
+    "avero": {
+      "title": "Avero – Facturació moderna i segura",
+      "description": "<strong>Avero</strong> és el nostre <strong>software SaaS de facturació</strong>, pensat per a <strong>autònoms i PIMEs</strong>. Et permet gestionar <strong>factures, pressupostos, albarans i TPV</strong> de forma simple, amb <strong>enviament automàtic a l’AEAT</strong> i total compliment legal amb <strong>Veri*Factu</strong>.",
+      "list": {
+        "pointOne": "Facturació electrònica completa i segura",
+        "pointTwo": "Pressupostos, albarans i TPV integrats",
+        "pointThree": "Gestió de clients i productes",
+        "pointFour": "Compliment normatiu amb Veri*Factu"
+      },
+      "primaryCta": "Coneix Avero",
+      "secondaryCta": "Prova Avero gratis",
+      "imageAlt": "Logotip d'Avero"
+    },
+    "customCta": {
+      "title": "Necessites un programa específic per la teva empresa?",
+      "description": "Vols estalviar temps optimitzant tasques amb un programari a mida!",
+      "button": "Contacta'ns",
+      "imageAlt": "Programari a mida"
+    },
+    "benefits": {
+      "title": "Què aportem als nostres clients",
+      "items": {
+        "trust": {
+          "alt": "Confiança",
+          "title": "Confiança",
+          "description": "Treballem perquè compleixis amb la normativa sense maldecaps, amb <strong>solucions fiables i segures</strong>."
+        },
+        "efficiency": {
+          "alt": "Eficiència",
+          "title": "Eficiència",
+          "description": "Optimitza el teu temps amb <strong>processos simplificats</strong> i un software intuïtiu."
+        },
+        "scalability": {
+          "alt": "Escalabilitat",
+          "title": "Escalabilitat",
+          "description": "Les nostres solucions creixen amb el teu negoci, adaptant-se a noves necessitats."
+        },
+        "partnerships": {
+          "alt": "Aliances estratègiques",
+          "title": "Aliances estratègiques",
+          "description": "Oferim a les <strong>gestories</strong> eines que obren <strong>nous canals d’ingressos</strong> i milloren el servei als seus clients."
+        }
+      }
+    },
+    "testimonials": {
+      "title": "Clients que confien en nosaltres",
+      "items": {
+        "ajuntament": {
+          "alt": "Ajuntament de L'Aldea",
+          "name": "Ajuntament de L'Aldea"
+        },
+        "egea": {
+          "alt": "EGEA Arquitectura",
+          "name": "EGEA Arquitectura"
+        },
+        "gerco": {
+          "alt": "GERCO Serveis Integrals",
+          "name": "GERCO Serveis Integrals"
+        }
+      }
+    },
+    "values": {
+      "title": "Els nostres valors",
+      "description": "A JCT Agency treballem amb una filosofia clara: oferir <strong>innovació, simplicitat, seguretat i proximitat</strong>.",
+      "items": {
+        "innovation": "<strong>Innovació</strong> – sempre a l’avantguarda tecnològica i legal.",
+        "simplicity": "<strong>Simplicitat</strong> – software intuïtiu que facilita el treball, no el complica.",
+        "compliance": "<strong>Compliment legal i seguretat</strong> – desenvolupem sistemes totalment adaptats a Veri*Factu i altres normatives.",
+        "support": "<strong>Proximitat i suport</strong> – ens involucrem en cada projecte com si fos nostre."
+      }
+    },
+    "blog": {
+      "title": "Recursos i guies útils",
+      "links": {
+        "digitalisation": "Com digitalitzar la gestió d’una PIME en 5 passos",
+        "verifactu": "Guia pràctica per a gestories sobre Veri*Factu",
+        "saas": "Per què un SaaS és millor que un software tradicional?"
+      }
+    },
+    "quoteSection": {
+      "title": "Vols una estimació del teu projecte?",
+      "description": "Utilitza la nostra calculadora per conèixer el pressupost aproximat.",
+      "button": "Calcula el teu pressupost"
+    },
+    "contact": {
+      "title": "Parlem del teu projecte?",
+      "description": "Si busques un partner tecnològic per digitalitzar la teva empresa, contacta amb nosaltres.",
+      "form": {
+        "name": "Nom i cognoms",
+        "company": "Empresa",
+        "email": "Email",
+        "message": "Missatge",
+        "submit": "Enviar missatge",
+        "success": "Missatge enviat!"
+      },
+      "details": {
+        "email": "info@jctagency.com",
+        "location": "Tarragona (Catalunya)",
+        "phone": "633 391 411"
+      }
+    }
+  },
+  "contact": {
+    "meta": {
+      "title": "JCT Agency - Contacte",
+      "description": "Contacta amb JCT Agency per rebre assessorament tecnològic i solucions digitals adaptades al teu negoci."
+    },
+    "title": "Contacte",
+    "intro": "Estem aquí per respondre les teves preguntes i ajudar-te en el teu projecte. Pots contactar amb nosaltres mitjançant:",
+    "info": {
+      "title": "Informació de contacte",
+      "addressLabel": "Direcció:",
+      "addressValue": "Online",
+      "emailLabel": "Email:",
+      "emailValue": "joan@jctagency.com",
+      "phoneLabel": "Telèfon:",
+      "phoneValue": "+34 633 391 411"
+    },
+    "form": {
+      "title": "Formulari de contacte",
+      "nameLabel": "Nom",
+      "namePlaceholder": "Nom complet",
+      "companyLabel": "Empresa",
+      "companyPlaceholder": "Nom de l'empresa",
+      "emailLabel": "Email",
+      "emailPlaceholder": "Correu electrònic",
+      "messageLabel": "Missatge",
+      "messagePlaceholder": "Explica'ns el teu projecte",
+      "submit": "Enviar",
+      "success": "Enviat!"
+    }
+  },
+  "pressupost": {
+    "meta": {
+      "title": "Calcula el teu pressupost | JCT Agency",
+      "description": "Calcula de manera orientativa el cost del teu projecte digital."
+    },
+    "title": "Calculadora de pressupost",
+    "form": {
+      "projectType": {
+        "label": "Tipus de projecte",
+        "placeholder": "Selecciona una opció",
+        "options": {
+          "web": "Pàgina web",
+          "software": "Programa a mida",
+          "app": "App mòbil"
+        },
+        "values": {
+          "web": "Pàgina web",
+          "software": "Programa a mida",
+          "app": "App mòbil"
+        }
+      },
+      "web": {
+        "pagesLabel": "Nombre de pàgines",
+        "pages": {
+          "options": {
+            "basic": "1-5",
+            "medium": "6-10",
+            "advanced": "Més de 10"
+          }
+        },
+        "ecommerce": "Incloure e-commerce"
+      },
+      "software": {
+        "modulesLabel": "Nombre de mòduls",
+        "modules": {
+          "options": {
+            "basic": "1-2",
+            "medium": "3-5",
+            "advanced": "6 o més"
+          }
+        },
+        "cloud": "Integració al núvol"
+      },
+      "app": {
+        "platformsLabel": "Plataformes",
+        "platforms": {
+          "options": {
+            "single": "iOS o Android",
+            "multiple": "iOS i Android"
+          }
+        },
+        "auth": "Autenticació d'usuaris"
+      },
+      "name": "Nom",
+      "company": "Empresa",
+      "email": "Email",
+      "submit": "Calcula pressupost",
+      "success": "Dades enviades correctament."
+    },
+    "emailMessage": "Servei: {{service}}\nDetalls: {{details}}\nPressupost: {{price}}€",
+    "result": {
+      "estimated": "Pressupost estimat: {{price}}€",
+      "nextStep": "Si el pressupost et quadra",
+      "contactCta": "Contacta"
+    }
+  },
+  "blog": {
+    "meta": {
+      "title": "Blog de JCT Agency | Recursos per a PIMEs i gestories",
+      "description": "Guies de digitalització, SEO i programari Veri*Factu per fer créixer el teu negoci i millorar la gestió empresarial."
+    },
+    "title": "Blog",
+    "posts": {
+      "seo": {
+        "title": "Optimització SEO per a PIMEs: 5 consells clau",
+        "excerpt": "Aprèn com millorar la visibilitat del teu negoci a Google amb tècniques senzilles i efectives."
+      },
+      "software": {
+        "title": "Beneficis del software a mida per a gestories i PIMEs",
+        "excerpt": "Descobreix per què invertir en solucions personalitzades pot impulsar l'eficiència del teu negoci."
+      },
+      "digital": {
+        "title": "Com digitalitzar la gestió d’una PIME en 5 passos",
+        "excerpt": "Guia pas a pas per modernitzar la teva empresa amb eines digitals accessibles i eficients."
+      },
+      "verifactu": {
+        "title": "Guia pràctica per a gestories sobre Veri*Factu",
+        "excerpt": "Tot el que has de saber sobre la nova normativa de facturació i com adaptar-t’hi sense complicacions."
+      },
+      "saas": {
+        "title": "Per què un SaaS és millor que un software tradicional?",
+        "excerpt": "Comparativa entre models per escollir la solució tecnològica més adequada per al teu negoci."
+      }
+    }
+  },
+  "avero": {
+    "meta": {
+      "title": "Avero – Programa de facturació 100% adaptat a VeriFactu i la Llei Crea y Crece",
+      "description": "Programa de facturació Avero per a autònoms, PIMEs i gestories; compleix Veri*Factu i la Llei Crea y Crece amb una eina senzilla i moderna."
+    },
+    "hero": {
+      "title": "Avero – Programa de facturació 100% adaptat a VeriFactu i la Llei Crea y Crece.*",
+      "description": "La solució més simple i moderna per a autònoms, PIMEs i gestories. Compleix amb la normativa sense complicacions.",
+      "primaryCta": "Prova Avero gratis",
+      "secondaryCta": "Demana una demo",
+      "imageAlt": "Mockup d'Avero",
+      "badge": "Adaptat a Veri*Factu – RD 1007/2023"
+    },
+    "why": {
+      "title": "Per què Avero?",
+      "description": "Avero és el programari de facturació creat per JCT Agency pensat per a cobrir les noves obligacions legals i simplificar la gestió diària de les empreses. Amb VeriFactu en vigor des de 2025 i l’entrada obligatòria al 2026, necessites un sistema segur, modern i validat per l’AEAT.*",
+      "keywords": "Software de facturació VeriFactu · Programa de factures Crea y Crece · Facturació per autònoms i PIMEs"
+    },
+    "features": {
+      "title": "Funcionalitats clau",
+      "blocks": {
+        "billing": {
+          "alt": "Facturació",
+          "title": "Facturació",
+          "items": [
+            "Factures electròniques (creació, enviament, rectificatives, simplificades).",
+            "Gestió de pressupostos i albarans, conversió en factura amb un clic.",
+            "Control de clients i proveïdors amb historial complet.",
+            "Gestió d’articles i productes (preus, categories, stock bàsic).",
+            "Enviament de factures per correu electrònic i PDF professional.",
+            "TPV integrat per a vendes físiques amb emissió de tiquets legals."
+          ]
+        },
+        "utilities": {
+          "alt": "Utilitats premium",
+          "title": "Utilitats premium",
+          "items": [
+            "Quadres de comandament i informes: ingressos, despeses, beneficis, IVA.",
+            "Gestió multiempresa i multiusuari amb rols i permisos.",
+            "Integració amb Stripe i passarel·les de pagament.",
+            "Signatura i certificat digital integrat per a remissió segura."
+          ]
+        },
+        "aeat": {
+          "alt": "AEAT",
+          "title": "AEAT",
+          "items": [
+            "Enviament automàtic a l’AEAT en temps real (modalitat Veri*Factu).",
+            "Còpies de seguretat i conservació de registres (complint el RRSIF).",
+            "Generació de codi QR tributari a les factures."
+          ]
+        }
+      }
+    },
+    "compliance": {
+      "title": "Compliment legal (Veri*Factu i Llei Crea y Crece)",
+      "items": [
+        "Veri*Factu: Avero envia cada factura a l’AEAT amb hash encadenat, registre inalterable i QR tributari.",
+        "Llei Crea y Crece: Factura electrònica obligatòria per a operacions B2B.",
+        "Normativa aplicable: RD 1007/2023, Ordre HAC/1177/2024 i modificacions RD 254/2025."
+      ],
+      "note": "Avero és el programari de facturació certificat i adaptat al reglament Veri*Factu (AEAT) i a la Llei Crea y Crece."
+    },
+    "target": {
+      "title": "Per a qui és Avero",
+      "description": "<strong>Avero</strong> està pensat per a <strong>autònoms, PIMEs i gestories</strong> que necessiten complir la normativa i millorar la seva operativa diària.",
+      "items": [
+        "Gestió completa de factures, pressupostos i clients des d’un únic lloc.",
+        "Control d’accés per rols per coordinar equips interns i gestories.",
+        "API i integracions per connectar Avero amb altres sistemes empresarials."
+      ]
+    },
+    "cta": {
+      "title": "Vols parlar amb un expert d’Avero?",
+      "description": "T’ajudem a adaptar el teu negoci a Veri*Factu i a la Llei Crea y Crece.",
+      "primaryCta": "Crear compte",
+      "secondaryCta": "Contacta amb un assessor"
+    },
+    "testimonials": {
+      "title": "Testimonis / Casos d’ús",
+      "man": {
+        "alt": "Client satisfet",
+        "quote": "“Amb Avero genero les meves factures en segons i sé que estan validades per l’AEAT.”"
+      },
+      "woman": {
+        "alt": "Client satisfet",
+        "quote": "“Hem estalviat hores setmanals en la gestió de clients i IVA.”"
+      }
+    },
+    "gallery": {
+      "title": "Galeria",
+      "description": "Descobreix captures de pantalla i exemples de l'entorn d'Avero."
+    },
+    "video": {
+      "title": "Vídeo explicatiu",
+      "description": "Pròximament disponible: un vídeo que mostra com funciona Avero pas a pas."
+    },
+    "finalCta": {
+      "title": "Adelanta’t a la normativa. Prova Avero avui i compleix amb Veri*Factu sense preocupacions.",
+      "primaryCta": "Crear compte",
+      "secondaryCta": "Contacta amb un assessor"
+    },
+    "footer": {
+      "links": {
+        "verifactu": "Programa de facturació VeriFactu",
+        "aeat": "Factures electròniques AEAT",
+        "software": "Software de facturació per autònoms i gestories"
+      }
+    }
+  },
+  "articles": {
+    "digitalitzarPime": {
+      "meta": {
+        "title": "Com digitalitzar la gestió d’una PIME en 5 passos | JCT Agency",
+        "description": "Passos clau per digitalitzar una PIME amb eines SaaS, estratègies de transformació digital i consells pràctics per millorar l'eficiència."
+      },
+      "title": "Com digitalitzar la gestió d’una PIME en 5 passos",
+      "sections": [
+        {
+          "paragraphs": [
+            "La digitalització ja no és una opció, és una necessitat per a qualsevol PIME que vulgui mantenir-se competitiva. Moltes petites empreses han funcionat durant anys amb processos manuals, documents en paper i eines disperses que compliquen el dia a dia. Aquest article pretén ser una guia detallada perquè qualsevol gestor o propietari pugui iniciar la transformació digital amb confiança. Des de la planificació inicial fins a la implementació d’eines i la formació de l’equip, t’expliquem com fer el pas a un model de gestió més eficient i orientat al futur."
+          ]
+        },
+        {
+          "heading": "1. Analitza l’estat actual i defineix objectius",
+          "paragraphs": [
+            "Abans d’adquirir programari o contractar serveis, és essencial entendre com funciona actualment l’empresa. Fes un inventari de processos: comptabilitat, gestió de clients, control d’estoc, tasques administratives i comunicació interna. Identifica els punts febles i aquelles activitats que generen més feina manual. A continuació, defineix objectius concrets de digitalització, com reduir el temps de facturació, millorar la traçabilitat de les comandes o augmentar la satisfacció del client. Aquests objectius han de ser mesurables i alineats amb l’estratègia global de la companyia. Comptar amb indicadors clau de rendiment permetrà valorar els avenços i ajustar el pla quan sigui necessari."
+          ]
+        },
+        {
+          "heading": "2. Escull les eines adequades",
+          "paragraphs": [
+            "El mercat ofereix una gran varietat d’eines digitals: gestors de facturació, CRMs, plataformes de comunicació, sistemes de gestió de projectes i aplicacions de comerç electrònic, entre d’altres. L’objectiu no és adquirir la solució més cara, sinó aquella que millor s’adapti als processos i pressupost de la PIME. Prioritza les aplicacions en el núvol, que permeten accedir a la informació des de qualsevol lloc i reduir els costos d’infraestructura. Valora també la possibilitat d’utilitzar programes modulars que puguin créixer a mesura que el negoci ho faci. Consulta opinions d’altres usuaris, demana demostracions i assegura’t que l’eina compleix amb la normativa vigent en matèria de protecció de dades i factura electrònica."
+          ]
+        },
+        {
+          "heading": "3. Integra els sistemes i automatitza processos",
+          "paragraphs": [
+            "Un cop seleccionades les eines, el següent pas és garantir que totes treballin de manera coordinada. Les integracions permeten que les dades circulin sense errors ni duplicacions. Per exemple, el CRM pot estar connectat amb el programa de facturació perquè les vendes es reflecteixin automàticament en la comptabilitat. També es poden automatitzar tasques com l’enviament de correus de seguiment, la generació d’informes o la sincronització d’estoc entre la botiga física i l’online. Dedica temps a definir els fluxos d’informació i utilitza APIs o connectors proporcionats pels proveïdors. Una bona integració no només estalvia temps, sinó que ofereix una visió global del negoci, facilitant la presa de decisions basada en dades."
+          ]
+        },
+        {
+          "heading": "4. Forma l’equip i promou la cultura digital",
+          "paragraphs": [
+            "La tecnologia per si sola no garanteix l’èxit. És fonamental que les persones que la utilitzaran se sentin còmodes i entenguin els avantatges del canvi. Organitza sessions de formació adaptades a cada departament i crea materials de suport com manuals o vídeos curts. Promou una cultura digital on l’aprenentatge continu sigui valorat i els errors es considerin una oportunitat de millora. Implica els treballadors en el procés, demanant la seva opinió i permetent-los proposar idees. Quan l’equip veu que la digitalització facilita la seva feina i elimina tasques repetitives, l’adopció és molt més ràpida i natural."
+          ]
+        },
+        {
+          "heading": "5. Mesura resultats i ajusta l’estratègia",
+          "paragraphs": [
+            "La transformació digital és un camí continu. Després d’implantar les eines i formar l’equip, és important establir un sistema de seguiment que permeti mesurar l’impacte. Utilitza indicadors com el temps de resposta als clients, el nombre d’errors en la facturació o el cost de gestió per projecte. Compara aquests valors amb els objectius inicials i detecta àrees de millora. Pot ser que calgui afegir noves funcionalitats, canviar un proveïdor o reforçar la formació en determinats punts. La flexibilitat és clau: la digitalització no és un projecte amb principi i final, sinó una evolució constant que ha d’acompanyar el creixement del negoci."
+          ]
+        },
+        {
+          "heading": "Beneficis addicionals de la digitalització",
+          "paragraphs": [
+            "A més d’optimitzar processos, la digitalització aporta una sèrie de beneficis transversals. Permet treballar de manera col·laborativa, independentment de la ubicació dels membres de l’equip, i facilita l’accés a noves oportunitats de negoci a través d’Internet. La disponibilitat de dades en temps real millora la presa de decisions i redueix els riscos. També contribueix a una imatge de marca més professional i innovadora, fet que pot atreure nous clients i partners. Finalment, moltes eines digitals estan preparades per complir amb normatives com el RGPD o VeriFactu, cosa que simplifica el compliment legal i evita sancions."
+          ]
+        },
+        {
+          "heading": "Conclusió",
+          "paragraphs": [
+            "Digitalitzar una PIME no ha de ser un procés traumàtic. Amb una planificació adequada i el suport de professionals, és possible transformar l’empresa de manera gradual i rendible. L’important és començar amb objectius clars, escollir les eines correctes i implicar tot l’equip en el canvi. A JCT Agency hem ajudat nombroses empreses a donar aquest pas, i sabem que els resultats arriben quan la tecnologia es combina amb una visió estratègica. Si estàs preparat per modernitzar la gestió del teu negoci, la digitalització és el camí que et permetrà créixer i afrontar amb garanties els reptes del futur."
+          ]
+        }
+      ]
+    },
+    "seo": {
+      "meta": {
+        "title": "Optimització SEO per a PIMEs: guia completa | JCT Agency",
+        "description": "Guia SEO per a PIMEs amb tècniques per posicionar la web a Google, atraure clients locals i optimitzar continguts."
+      },
+      "title": "Optimització SEO per a PIMEs: guia completa",
+      "sections": [
+        {
+          "paragraphs": [
+            "El posicionament orgànic en cercadors és un dels pilars per generar trànsit qualificat cap a la teva web sense dependre exclusivament de la publicitat de pagament. Per a una PIME, invertir en SEO significa establir una base sòlida que li permeti competir amb empreses més grans i arribar a nous clients potencials. En aquesta guia aprofundirem en les principals estratègies que pots aplicar avui mateix. L’article està pensat perquè sigui una referència completa: trobaràs recomanacions pràctiques, exemples reals i consells sobre com implementar-les amb recursos limitats. L’objectiu és que puguis entendre cada pas i portar-lo a la pràctica sense necessitat de coneixements tècnics avançats."
+          ]
+        },
+        {
+          "heading": "1. Investigació de paraules clau",
+          "paragraphs": [
+            "Abans de redactar qualsevol peça de contingut és imprescindible saber quins termes utilitzen els teus clients quan busquen informació relacionada amb el teu producte o servei. Comença fent una llista de possibles paraules i expressions, incloent sinònims i consultes de llarga cua. Eines com Google Keyword Planner, Ubersuggest o AnswerThePublic et permeten conèixer el volum de cerques, la dificultat i les tendències. Dedica temps a entendre la intenció de cada cerca: no és el mateix “gestoria per autònoms a Barcelona” que “com portar la comptabilitat d’un autònom”. Aquesta fase et servirà per crear contingut que respongui exactament el que necessita l’usuari, millorant la rellevància i augmentant les opcions d’aparèixer als primers resultats de Google."
+          ]
+        },
+        {
+          "heading": "2. Contingut de qualitat i estratègia editorial",
+          "paragraphs": [
+            "Una vegada identificades les paraules clau, és hora de desenvolupar una estratègia editorial. El contingut ha de ser útil, original i centrat en resoldre problemes reals. Planifica un calendari de publicacions que combini articles informatius, guies i casos d’èxit. És recomanable mantenir una estructura clara amb títols, subtítols i llistes que facilitin la lectura. Inclou imatges optimitzades amb textos alternatius descriptius i, sempre que sigui possible, afegeix exemples propis de la teva activitat empresarial. Recorda que l’actualització periòdica del contingut és clau: Google valora les webs que es mantenen vives i que aporten novetats de forma constant. A més, una bona estratègia editorial afavoreix que altres webs enllacin als teus articles, incrementant l’autoritat del domini."
+          ]
+        },
+        {
+          "heading": "3. SEO local i fitxes de Google Business",
+          "paragraphs": [
+            "Si el teu negoci té una ubicació física o presta serveis en una zona geogràfica concreta, treballar el SEO local és imprescindible. El primer pas és crear i optimitzar la fitxa de Google Business Profile, assegurant-te que la informació de contacte, horaris i categories és correcta. Anima els teus clients a deixar ressenyes i respon-les sempre, ja que són un factor de posicionament i reforcen la confiança. Al web, inclou la teva localització a les pàgines de serveis i al peu de pàgina, utilitzant dades estructurades perquè els cercadors entenguin millor on operes. Publicar contingut relacionat amb la teva ciutat o comarca també ajuda a atraure trànsit qualificat que busca solucions a prop seu."
+          ]
+        },
+        {
+          "heading": "4. Optimització tècnica de la web",
+          "paragraphs": [
+            "Una web ràpida i sense errors és fonamental perquè el teu esforç en continguts doni resultats. Revisa periòdicament la velocitat de càrrega amb eines com PageSpeed Insights o Lighthouse i aplica les millores recomanades: compressió d’imatges, minificació de recursos i implementació de memòria cau. El web ha de ser totalment responsive, adaptant-se a mòbils i tauletes, i utilitzar el protocol HTTPS per garantir la seguretat. També és important disposar d’un mapa del lloc i un fitxer robots.txt correctament configurats perquè Google pugui rastrejar les pàgines sense problemes. Els errors 404 i els enllaços trencats han de solucionar-se ràpidament per evitar penalitzacions i mala experiència d’usuari."
+          ]
+        },
+        {
+          "heading": "5. Estratègia d’enllaçat intern",
+          "paragraphs": [
+            "Crear una xarxa d’enllaços interna coherent facilita que els cercadors entenguin l’estructura del teu lloc i distribueix l’autoritat entre les diferents pàgines. Cada vegada que publiquis un nou article, enllaça’l amb contingut relacionat que ja existeixi al teu web. Això prolonga el temps de sessió dels usuaris i redueix la taxa de rebot. Utilitza textos d’àncora descriptius, evitant frases genèriques com “fes clic aquí”. Les pàgines més importants haurien de rebre més enllaços interns, i és recomanable fer un seguiment regular per detectar oportunitats d’enllaçat que ajudin a posicionar paraules clau concretes. Un bon enllaçat intern també serveix per guiar l’usuari cap a la conversió, ja sigui omplir un formulari, descarregar un recurs o contractar un servei."
+          ]
+        },
+        {
+          "heading": "6. Link building i col·laboracions",
+          "paragraphs": [
+            "Els enllaços que provenen d’altres webs continuen sent un dels factors de posicionament més rellevants. Per a una PIME, la clau és aconseguir backlinks de qualitat sense recórrer a pràctiques dubtoses. Pots col·laborar amb blogs del teu sector, participar en esdeveniments i publicar notes de premsa en mitjans locals. Els directors d’empreses, associacions professionals o proveïdors també poden enllaçar el teu lloc si ofereixes contingut d’interès. Prioritza la qualitat sobre la quantitat: un sol enllaç d’una web amb autoritat pot ser més valuós que desenes de baixa qualitat. A més, diversifica els textos d’àncora i evita un patró artificial que pugui aixecar sospites als algoritmes de Google."
+          ]
+        },
+        {
+          "heading": "7. Experiència d’usuari i Core Web Vitals",
+          "paragraphs": [
+            "Google ha incorporat les Core Web Vitals com a indicador clau de l’experiència d’usuari. Aquests paràmetres mesuren la velocitat de càrrega, l’estabilitat visual i la interactivitat de la pàgina. Per optimitzar-los, redueix els scripts innecessaris, utilitza fonts web eficients i reserva espai per a les imatges per evitar moviments inesperats. Una experiència d’usuari positiva no només ajuda al posicionament, sinó que també augmenta la probabilitat de conversió. Recorda que el SEO i la usabilitat van de la mà: quan l’usuari troba ràpidament allò que busca i navega sense dificultats, és més probable que torni i recomani el teu web."
+          ]
+        },
+        {
+          "heading": "8. Analítica i millora contínua",
+          "paragraphs": [
+            "Ninguna estratègia SEO està completa sense un sistema de mesura que permeti avaluar els resultats. Configura Google Analytics i Google Search Console per monitoritzar el trànsit, les paraules clau que generen visites i el comportament dels usuaris. Estableix objectius clars, com ara conversions o descàrregues, i fes un seguiment periòdic per identificar quines pàgines funcionen millor. L’analítica també serveix per detectar contingut obsolet o paraules clau emergents que val la pena treballar. El SEO és un procés iteratiu: analitza, aprèn i aplica millores constants per mantenir-te per davant de la competència."
+          ]
+        },
+        {
+          "heading": "9. Automatització i eines de suport",
+          "paragraphs": [
+            "Tot i que moltes accions SEO es poden fer manualment, utilitzar eines d’automatització pot estalviar temps i recursos. Plataformes com Screaming Frog, SEMrush o Ahrefs permeten auditar el web, detectar errors tècnics i monitoritzar l’estratègia de link building. També pots programar alertes per conèixer quan un competidor publica nou contingut o quan rep un enllaç rellevant. L’automatització no substitueix la creativitat ni la planificació estratègica, però sí que facilita la gestió del dia a dia i permet concentrar-te en tasques de més valor, com la creació de contingut o el desenvolupament de nous serveis."
+          ]
+        },
+        {
+          "heading": "10. Conclusions i pròxims passos",
+          "paragraphs": [
+            "Implementar una estratègia SEO efectiva requereix constància i una visió a llarg termini. Les PIMEs que aposten per aquesta disciplina aconsegueixen una presència en línia més sòlida, un flux de clients potencials sostingut i una imatge de marca reforçada. Comença pels aspectes bàsics: una bona investigació de paraules clau, contingut rellevant i una web tècnicament optimitzada. A mesura que vagis obtenint resultats, amplia les accions amb estratègies de link building, millores d’experiència d’usuari i automatització. Recorda que el SEO és una carrera de fons: cada acció suma i, amb perseverança, el teu negoci pot destacar en un entorn digital cada vegada més competitiu."
+          ]
+        }
+      ]
+    },
+    "software": {
+      "meta": {
+        "title": "Beneficis del software a mida per a gestories i PIMEs | JCT Agency",
+        "description": "Avantatges del desenvolupament de software a mida per optimitzar processos en gestories i petites empreses."
+      },
+      "title": "Beneficis del software a mida per a gestories i PIMEs",
+      "sections": [
+        {
+          "paragraphs": [
+            "El software a mida s’ha convertit en una eina clau per a gestories i PIMEs que necessiten solucions específiques per als seus processos interns. A diferència de les eines genèriques, el desenvolupament personalitzat permet adaptar les funcionalitats exactes a les necessitats del negoci, integrant-se amb altres sistemes i garantint la seguretat de les dades. En aquest article repassem els principals beneficis i com pot impactar directament en la productivitat de l’empresa."
+          ]
+        },
+        {
+          "heading": "1. Automatització de processos repetitius",
+          "paragraphs": [
+            "Amb un software a mida és possible automatitzar tasques que abans requerien hores de treball manual. Des de la generació de documents fiscals fins a l’enviament d’avisos als clients, la tecnologia permet reduir errors i alliberar temps perquè els equips es focalitzin en tasques de més valor."
+          ]
+        },
+        {
+          "heading": "2. Integració amb altres eines",
+          "paragraphs": [
+            "Les gestories i PIMEs sovint utilitzen múltiples aplicacions: programes de comptabilitat, CRMs, plataformes de facturació o eines de signatura digital. Un software a mida permet integrar totes aquestes solucions en un únic entorn, evitant la duplicació de dades i millorant la traçabilitat de la informació."
+          ]
+        },
+        {
+          "heading": "3. Compliment normatiu assegurat",
+          "paragraphs": [
+            "El marc legal evoluciona constantment i obliga les empreses a mantenir-se al dia. Desenvolupar software a mida garanteix que totes les actualitzacions normatives s’apliquin de manera centralitzada, reduint el risc de sancions i facilitant auditories internes."
+          ]
+        },
+        {
+          "heading": "4. Experiència d’usuari personalitzada",
+          "paragraphs": [
+            "Cada equip treballa de manera diferent. Un software a mida es pot dissenyar perquè l’experiència d’usuari sigui intuïtiva i adaptada al flux de treball de cada departament, incrementant l’adopció i la satisfacció dels treballadors."
+          ]
+        },
+        {
+          "heading": "5. Escalabilitat i flexibilitat",
+          "paragraphs": [
+            "A mesura que la gestoria o la PIME creix, també ho fan les seves necessitats. El software a mida permet afegir noves funcionalitats, perfils d’usuari o integracions sense haver de canviar d’eina, assegurant una inversió a llarg termini."
+          ]
+        },
+        {
+          "heading": "Conclusió",
+          "paragraphs": [
+            "Invertir en software a mida és apostar per una solució que acompanya el creixement del negoci. A JCT Agency dissenyem i desenvolupem aplicacions adaptades a cada projecte, amb un enfocament en la seguretat, la usabilitat i el compliment legal."
+          ]
+        }
+      ]
+    },
+    "verifactu": {
+      "meta": {
+        "title": "Guia pràctica per a gestories sobre Veri*Factu | JCT Agency",
+        "description": "Aspectes clau de Veri*Factu per a gestories: obligacions, terminis i com adaptar-se a la normativa."
+      },
+      "title": "Guia pràctica per a gestories sobre Veri*Factu",
+      "sections": [
+        {
+          "paragraphs": [
+            "Veri*Factu és el sistema que l’AEAT ha impulsat per garantir la integritat i autenticitat dels registres de facturació. Per a les gestories, conèixer-ne els detalls és essencial per assessorar correctament els seus clients i adaptar els processos interns."
+          ]
+        },
+        {
+          "heading": "1. Què és Veri*Factu?",
+          "paragraphs": [
+            "És un marc normatiu que obliga a enviar les factures a l’AEAT en temps real, garantint que no es poden manipular posteriorment. Cada factura genera un codi hash i un registre inalterable."
+          ]
+        },
+        {
+          "heading": "2. Qui ha de complir la normativa?",
+          "paragraphs": [
+            "Totes les empreses i professionals que emeten factures han d’adaptar els seus sistemes a Veri*Factu abans de l’entrada en vigor obligatòria. Les gestories han de preparar-se per oferir eines que compleixin amb aquests requisits."
+          ]
+        },
+        {
+          "heading": "3. Quines funcionalitats ha de tenir el software?",
+          "paragraphs": [
+            "El programa ha de generar codis QR tributaris, conservar registres segurs, evitar la manipulació d’assentaments i permetre l’enviament immediat a l’AEAT. També ha de portar un registre d’esdeveniments i assegurar còpies de seguretat."
+          ]
+        },
+        {
+          "heading": "4. Com pot ajudar una gestoria als seus clients?",
+          "paragraphs": [
+            "Implementant un software certificat com Avero, oferint formació sobre la nova normativa i monitoritzant que totes les factures es transmetin correctament."
+          ]
+        },
+        {
+          "heading": "5. Beneficis d’adaptar-se aviat",
+          "paragraphs": [
+            "Adoptar Veri*Factu amb temps permet evitar sancions, millorar la relació amb els clients i posicionar la gestoria com a referent en compliment normatiu i transformació digital."
+          ]
+        }
+      ]
+    },
+    "saas": {
+      "meta": {
+        "title": "Per què un SaaS és millor que un software tradicional? | JCT Agency",
+        "description": "Comparativa entre software SaaS i solucions tradicionals per decidir la millor opció per al teu negoci."
+      },
+      "title": "Per què un SaaS és millor que un software tradicional?",
+      "sections": [
+        {
+          "paragraphs": [
+            "Escollir entre un software SaaS (Software as a Service) i una solució tradicional instal·lada en servidors propis és una decisió clau per a moltes empreses. A continuació analitzem les diferències principals per ajudar-te a prendre la millor decisió."
+          ]
+        },
+        {
+          "heading": "1. Cost inicial i manteniment",
+          "paragraphs": [
+            "El model SaaS funciona sota subscripció i evita una gran inversió inicial en llicències i infraestructura. El software tradicional requereix equips, instal·lacions i actualitzacions costoses."
+          ]
+        },
+        {
+          "heading": "2. Actualitzacions i seguretat",
+          "paragraphs": [
+            "Amb SaaS, el proveïdor s’encarrega de les actualitzacions automàtiques, millores de seguretat i còpies de seguretat. En un entorn tradicional, l’empresa ha de gestionar aquests processos manualment."
+          ]
+        },
+        {
+          "heading": "3. Escalabilitat",
+          "paragraphs": [
+            "El SaaS permet ampliar o reduir usuaris i funcionalitats amb facilitat. Les solucions tradicionals exigeixen planificació i inversió en maquinari addicional."
+          ]
+        },
+        {
+          "heading": "4. Accessibilitat",
+          "paragraphs": [
+            "Un software SaaS és accessible des de qualsevol dispositiu connectat a Internet, facilitant el teletreball i la col·laboració. El software tradicional sol limitar-se a l’oficina o requereix configuracions VPN complexes."
+          ]
+        },
+        {
+          "heading": "5. Integracions",
+          "paragraphs": [
+            "Moltes solucions SaaS ofereixen APIs i connectors per integrar-se amb altres eines del mercat. Les aplicacions tradicionals poden necessitar desenvolupaments a mida i més temps per aconseguir la mateixa connexió."
+          ]
+        },
+        {
+          "heading": "Conclusió",
+          "paragraphs": [
+            "El model SaaS destaca per la seva flexibilitat, seguretat i rapidesa de desplegament. Tot i això, és important analitzar les necessitats específiques de cada empresa per escollir la solució que aporti més valor a llarg termini."
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,700 @@
+{
+  "common": {
+    "brandAlt": "JCT Agency"
+  },
+  "navigation": {
+    "home": "Inicio",
+    "avero": "Avero",
+    "blog": "Blog",
+    "quote": "Presupuesto",
+    "contact": "Contacto"
+  },
+  "language": {
+    "label": "Selecciona idioma",
+    "options": {
+      "ca": "Catalán",
+      "es": "Castellano"
+    }
+  },
+  "layout": {
+    "footer": {
+      "logoAlt": "Logo JCT Agency",
+      "copy": "© 2024 JCT Agency – Soluciones digitales y software SaaS.",
+      "contact": "Email: joan@jctagency.com | Teléfono: 633 391 411",
+      "follow": "Síguenos en LinkedIn"
+    }
+  },
+  "home": {
+    "meta": {
+      "title": "JCT Agency | Soluciones digitales para hacer crecer tu negocio",
+      "description": "Agencia digital catalana especialista en software SaaS y soluciones tecnológicas para autónomos, pymes y gestorías."
+    },
+    "hero": {
+      "title": "JCT Agency – Soluciones digitales para autónomos, pymes y gestorías",
+      "description": "Somos una agencia tecnológica especializada en <strong>software SaaS</strong> y <strong>programas empresariales</strong> que simplifican la gestión y garantizan el <strong>cumplimiento legal con Veri*Factu</strong>.",
+      "ctaServices": "Descubre nuestros servicios",
+      "ctaContact": "Habla con nosotros",
+      "imageAlt": "Equipo de JCT Agency"
+    },
+    "clients": {
+      "title": "Ayudamos a empresas como la tuya",
+      "description": "Nuestro software está pensado para <strong>autónomos</strong>, <strong>pymes</strong> y <strong>gestorías</strong> que quieren digitalizarse sin complicaciones.",
+      "items": {
+        "autonomous": {
+          "alt": "Autónomos",
+          "title": "Autónomos",
+          "description": "Soluciones adaptadas a profesionales independientes."
+        },
+        "smes": {
+          "alt": "Pymes",
+          "title": "Pymes",
+          "description": "Herramientas modernas para optimizar la gestión empresarial."
+        },
+        "accountants": {
+          "alt": "Gestorías",
+          "title": "Gestorías",
+          "description": "Software que facilita nuevos servicios digitales a tus clientes."
+        }
+      }
+    },
+    "services": {
+      "title": "Nuestros servicios",
+      "description": "En JCT Agency ofrecemos servicios digitales para impulsar el crecimiento y la eficiencia de tu negocio.",
+      "learnMore": "Más información",
+      "items": {
+        "software": {
+          "alt": "Desarrollo de software empresarial",
+          "title": "Desarrollo de software empresarial",
+          "description": "Creamos <strong>software propio</strong>, <strong>soluciones SaaS</strong> e <strong>integraciones con servicios externos</strong> para que tu empresa trabaje con herramientas modernas y seguras."
+        },
+        "consulting": {
+          "alt": "Consultoría tecnológica y legal",
+          "title": "Consultoría tecnológica y legal",
+          "description": "Te asesoramos en <strong>nuevas normativas</strong>, <strong>estrategias de digitalización</strong> y cumplimiento con <strong>Veri*Factu</strong>, para que siempre vayas un paso por delante."
+        },
+        "web": {
+          "alt": "Diseño y mantenimiento web",
+          "title": "Diseño y mantenimiento web",
+          "description": "Creamos y gestionamos <strong>webs corporativas</strong> modernas, con <strong>mantenimiento continuo</strong>, actualizaciones y seguridad garantizada."
+        },
+        "support": {
+          "alt": "Soporte continuado",
+          "title": "Soporte continuado",
+          "description": "Nos implicamos en tus proyectos con <strong>atención cercana</strong> y <strong>evolución constante del software</strong>, para que tu negocio nunca se detenga."
+        }
+      }
+    },
+    "avero": {
+      "title": "Avero – Facturación moderna y segura",
+      "description": "<strong>Avero</strong> es nuestro <strong>software SaaS de facturación</strong>, pensado para <strong>autónomos y pymes</strong>. Permite gestionar <strong>facturas, presupuestos, albaranes y TPV</strong> de forma sencilla, con <strong>envío automático a la AEAT</strong> y total cumplimiento legal con <strong>Veri*Factu</strong>.",
+      "list": {
+        "pointOne": "Facturación electrónica completa y segura",
+        "pointTwo": "Presupuestos, albaranes y TPV integrados",
+        "pointThree": "Gestión de clientes y productos",
+        "pointFour": "Cumplimiento normativo con Veri*Factu"
+      },
+      "primaryCta": "Conoce Avero",
+      "secondaryCta": "Prueba Avero gratis",
+      "imageAlt": "Logotipo de Avero"
+    },
+    "customCta": {
+      "title": "¿Necesitas un programa específico para tu empresa?",
+      "description": "¡Ahorra tiempo optimizando tareas con un software a medida!",
+      "button": "Contacta",
+      "imageAlt": "Software a medida"
+    },
+    "benefits": {
+      "title": "Qué aportamos a nuestros clientes",
+      "items": {
+        "trust": {
+          "alt": "Confianza",
+          "title": "Confianza",
+          "description": "Trabajamos para que cumplas la normativa sin complicaciones, con <strong>soluciones fiables y seguras</strong>."
+        },
+        "efficiency": {
+          "alt": "Eficiencia",
+          "title": "Eficiencia",
+          "description": "Optimiza tu tiempo con <strong>procesos simplificados</strong> y un software intuitivo."
+        },
+        "scalability": {
+          "alt": "Escalabilidad",
+          "title": "Escalabilidad",
+          "description": "Nuestras soluciones crecen con tu negocio, adaptándose a nuevas necesidades."
+        },
+        "partnerships": {
+          "alt": "Alianzas estratégicas",
+          "title": "Alianzas estratégicas",
+          "description": "Ofrecemos a las <strong>gestorías</strong> herramientas que abren <strong>nuevas vías de ingresos</strong> y mejoran el servicio a sus clientes."
+        }
+      }
+    },
+    "testimonials": {
+      "title": "Clientes que confían en nosotros",
+      "items": {
+        "ajuntament": {
+          "alt": "Ajuntament de L'Aldea",
+          "name": "Ajuntament de L'Aldea"
+        },
+        "egea": {
+          "alt": "EGEA Arquitectura",
+          "name": "EGEA Arquitectura"
+        },
+        "gerco": {
+          "alt": "GERCO Serveis Integrals",
+          "name": "GERCO Serveis Integrals"
+        }
+      }
+    },
+    "values": {
+      "title": "Nuestros valores",
+      "description": "En JCT Agency trabajamos con una filosofía clara: ofrecer <strong>innovación, simplicidad, seguridad y proximidad</strong>.",
+      "items": {
+        "innovation": "<strong>Innovación</strong> – siempre a la vanguardia tecnológica y legal.",
+        "simplicity": "<strong>Simplicidad</strong> – software intuitivo que facilita el trabajo, no lo complica.",
+        "compliance": "<strong>Cumplimiento legal y seguridad</strong> – desarrollamos sistemas totalmente adaptados a Veri*Factu y otras normativas.",
+        "support": "<strong>Proximidad y soporte</strong> – nos implicamos en cada proyecto como si fuera nuestro."
+      }
+    },
+    "blog": {
+      "title": "Recursos y guías útiles",
+      "links": {
+        "digitalisation": "Cómo digitalizar la gestión de una pyme en 5 pasos",
+        "verifactu": "Guía práctica para gestorías sobre Veri*Factu",
+        "saas": "¿Por qué un SaaS es mejor que un software tradicional?"
+      }
+    },
+    "quoteSection": {
+      "title": "¿Quieres una estimación de tu proyecto?",
+      "description": "Utiliza nuestra calculadora para conocer el presupuesto aproximado.",
+      "button": "Calcula tu presupuesto"
+    },
+    "contact": {
+      "title": "¿Hablamos de tu proyecto?",
+      "description": "Si buscas un partner tecnológico para digitalizar tu empresa, contacta con nosotros.",
+      "form": {
+        "name": "Nombre y apellidos",
+        "company": "Empresa",
+        "email": "Email",
+        "message": "Mensaje",
+        "submit": "Enviar mensaje",
+        "success": "¡Mensaje enviado!"
+      },
+      "details": {
+        "email": "info@jctagency.com",
+        "location": "Tarragona (Cataluña)",
+        "phone": "633 391 411"
+      }
+    }
+  },
+  "contact": {
+    "meta": {
+      "title": "JCT Agency - Contacto",
+      "description": "Contacta con JCT Agency para recibir asesoramiento tecnológico y soluciones digitales adaptadas a tu negocio."
+    },
+    "title": "Contacto",
+    "intro": "Estamos aquí para responder tus preguntas y ayudarte en tu proyecto. Puedes contactar con nosotros mediante:",
+    "info": {
+      "title": "Información de contacto",
+      "addressLabel": "Dirección:",
+      "addressValue": "Online",
+      "emailLabel": "Email:",
+      "emailValue": "joan@jctagency.com",
+      "phoneLabel": "Teléfono:",
+      "phoneValue": "+34 633 391 411"
+    },
+    "form": {
+      "title": "Formulario de contacto",
+      "nameLabel": "Nombre",
+      "namePlaceholder": "Nombre completo",
+      "companyLabel": "Empresa",
+      "companyPlaceholder": "Nombre de la empresa",
+      "emailLabel": "Email",
+      "emailPlaceholder": "Correo electrónico",
+      "messageLabel": "Mensaje",
+      "messagePlaceholder": "Cuéntanos tu proyecto",
+      "submit": "Enviar",
+      "success": "¡Enviado!"
+    }
+  },
+  "pressupost": {
+    "meta": {
+      "title": "Calcula tu presupuesto | JCT Agency",
+      "description": "Calcula de forma orientativa el coste de tu proyecto digital."
+    },
+    "title": "Calculadora de presupuesto",
+    "form": {
+      "projectType": {
+        "label": "Tipo de proyecto",
+        "placeholder": "Selecciona una opción",
+        "options": {
+          "web": "Página web",
+          "software": "Programa a medida",
+          "app": "App móvil"
+        },
+        "values": {
+          "web": "Página web",
+          "software": "Programa a medida",
+          "app": "App móvil"
+        }
+      },
+      "web": {
+        "pagesLabel": "Número de páginas",
+        "pages": {
+          "options": {
+            "basic": "1-5",
+            "medium": "6-10",
+            "advanced": "Más de 10"
+          }
+        },
+        "ecommerce": "Incluir e-commerce"
+      },
+      "software": {
+        "modulesLabel": "Número de módulos",
+        "modules": {
+          "options": {
+            "basic": "1-2",
+            "medium": "3-5",
+            "advanced": "6 o más"
+          }
+        },
+        "cloud": "Integración en la nube"
+      },
+      "app": {
+        "platformsLabel": "Plataformas",
+        "platforms": {
+          "options": {
+            "single": "iOS o Android",
+            "multiple": "iOS y Android"
+          }
+        },
+        "auth": "Autenticación de usuarios"
+      },
+      "name": "Nombre",
+      "company": "Empresa",
+      "email": "Email",
+      "submit": "Calcular presupuesto",
+      "success": "Datos enviados correctamente."
+    },
+    "emailMessage": "Servicio: {{service}}\nDetalles: {{details}}\nPresupuesto: {{price}}€",
+    "result": {
+      "estimated": "Presupuesto estimado: {{price}}€",
+      "nextStep": "Si el presupuesto encaja",
+      "contactCta": "Contacta"
+    }
+  },
+  "blog": {
+    "meta": {
+      "title": "Blog de JCT Agency | Recursos para pymes y gestorías",
+      "description": "Guías de digitalización, SEO y software Veri*Factu para hacer crecer tu negocio y mejorar la gestión empresarial."
+    },
+    "title": "Blog",
+    "posts": {
+      "seo": {
+        "title": "Optimización SEO para pymes: 5 consejos clave",
+        "excerpt": "Aprende cómo mejorar la visibilidad de tu negocio en Google con técnicas sencillas y efectivas."
+      },
+      "software": {
+        "title": "Beneficios del software a medida para gestorías y pymes",
+        "excerpt": "Descubre por qué invertir en soluciones personalizadas puede impulsar la eficiencia de tu negocio."
+      },
+      "digital": {
+        "title": "Cómo digitalizar la gestión de una pyme en 5 pasos",
+        "excerpt": "Guía paso a paso para modernizar tu empresa con herramientas digitales accesibles y eficientes."
+      },
+      "verifactu": {
+        "title": "Guía práctica para gestorías sobre Veri*Factu",
+        "excerpt": "Todo lo que debes saber sobre la nueva normativa de facturación y cómo adaptarte sin complicaciones."
+      },
+      "saas": {
+        "title": "¿Por qué un SaaS es mejor que un software tradicional?",
+        "excerpt": "Comparativa entre modelos para elegir la solución tecnológica más adecuada para tu negocio."
+      }
+    }
+  },
+  "avero": {
+    "meta": {
+      "title": "Avero – Programa de facturación 100% adaptado a VeriFactu y la Ley Crea y Crece",
+      "description": "Programa de facturación Avero para autónomos, pymes y gestorías; cumple Veri*Factu y la Ley Crea y Crece con una herramienta sencilla y moderna."
+    },
+    "hero": {
+      "title": "Avero – Programa de facturación 100% adaptado a VeriFactu y la Ley Crea y Crece.*",
+      "description": "La solución más simple y moderna para autónomos, pymes y gestorías. Cumple con la normativa sin complicaciones.",
+      "primaryCta": "Prueba Avero gratis",
+      "secondaryCta": "Solicita una demo",
+      "imageAlt": "Mockup de Avero",
+      "badge": "Adaptado a Veri*Factu – RD 1007/2023"
+    },
+    "why": {
+      "title": "¿Por qué Avero?",
+      "description": "Avero es el software de facturación creado por JCT Agency pensado para cubrir las nuevas obligaciones legales y simplificar la gestión diaria de las empresas. Con VeriFactu en vigor desde 2025 y la entrada obligatoria en 2026, necesitas un sistema seguro, moderno y validado por la AEAT.*",
+      "keywords": "Software de facturación VeriFactu · Programa de facturas Crea y Crece · Facturación para autónomos y pymes"
+    },
+    "features": {
+      "title": "Funcionalidades clave",
+      "blocks": {
+        "billing": {
+          "alt": "Facturación",
+          "title": "Facturación",
+          "items": [
+            "Facturas electrónicas (creación, envío, rectificativas, simplificadas).",
+            "Gestión de presupuestos y albaranes, conversión en factura con un clic.",
+            "Control de clientes y proveedores con historial completo.",
+            "Gestión de artículos y productos (precios, categorías, stock básico).",
+            "Envío de facturas por correo electrónico y PDF profesional.",
+            "TPV integrado para ventas físicas con emisión de tickets legales."
+          ]
+        },
+        "utilities": {
+          "alt": "Utilidades premium",
+          "title": "Utilidades premium",
+          "items": [
+            "Cuadros de mando e informes: ingresos, gastos, beneficios, IVA.",
+            "Gestión multiempresa y multiusuario con roles y permisos.",
+            "Integración con Stripe y pasarelas de pago.",
+            "Firma y certificado digital integrados para un envío seguro."
+          ]
+        },
+        "aeat": {
+          "alt": "AEAT",
+          "title": "AEAT",
+          "items": [
+            "Envío automático a la AEAT en tiempo real (modalidad Veri*Factu).",
+            "Copias de seguridad y conservación de registros (cumpliendo el RRSIF).",
+            "Generación de código QR tributario en las facturas."
+          ]
+        }
+      }
+    },
+    "compliance": {
+      "title": "Cumplimiento legal (Veri*Factu y Ley Crea y Crece)",
+      "items": [
+        "Veri*Factu: Avero envía cada factura a la AEAT con hash encadenado, registro inalterable y QR tributario.",
+        "Ley Crea y Crece: Factura electrónica obligatoria para operaciones B2B.",
+        "Normativa aplicable: RD 1007/2023, Orden HAC/1177/2024 y modificaciones RD 254/2025."
+      ],
+      "note": "Avero es el software de facturación certificado y adaptado al reglamento Veri*Factu (AEAT) y a la Ley Crea y Crece."
+    },
+    "target": {
+      "title": "¿Para quién es Avero?",
+      "description": "<strong>Avero</strong> está pensado para <strong>autónomos, pymes y gestorías</strong> que necesitan cumplir la normativa y mejorar su operativa diaria.",
+      "items": [
+        "Gestión completa de facturas, presupuestos y clientes desde un único lugar.",
+        "Control de acceso por roles para coordinar equipos internos y gestorías.",
+        "API e integraciones para conectar Avero con otros sistemas empresariales."
+      ]
+    },
+    "cta": {
+      "title": "¿Quieres hablar con un experto de Avero?",
+      "description": "Te ayudamos a adaptar tu negocio a Veri*Factu y a la Ley Crea y Crece.",
+      "primaryCta": "Crear cuenta",
+      "secondaryCta": "Contacta con un asesor"
+    },
+    "testimonials": {
+      "title": "Testimonios / Casos de uso",
+      "man": {
+        "alt": "Cliente satisfecho",
+        "quote": "“Con Avero genero mis facturas en segundos y sé que están validadas por la AEAT.”"
+      },
+      "woman": {
+        "alt": "Clienta satisfecha",
+        "quote": "“Hemos ahorrado horas semanales en la gestión de clientes e IVA.”"
+      }
+    },
+    "gallery": {
+      "title": "Galería",
+      "description": "Descubre capturas de pantalla y ejemplos del entorno de Avero."
+    },
+    "video": {
+      "title": "Vídeo explicativo",
+      "description": "Próximamente disponible: un vídeo que muestra cómo funciona Avero paso a paso."
+    },
+    "finalCta": {
+      "title": "Adelántate a la normativa. Prueba Avero hoy y cumple con Veri*Factu sin preocupaciones.",
+      "primaryCta": "Crear cuenta",
+      "secondaryCta": "Contacta con un asesor"
+    },
+    "footer": {
+      "links": {
+        "verifactu": "Programa de facturación VeriFactu",
+        "aeat": "Facturas electrónicas AEAT",
+        "software": "Software de facturación para autónomos y gestorías"
+      }
+    }
+  },
+  "articles": {
+    "digitalitzarPime": {
+      "meta": {
+        "title": "Cómo digitalizar la gestión de una pyme en 5 pasos | JCT Agency",
+        "description": "Pasos clave para digitalizar una pyme con herramientas SaaS, estrategias de transformación digital y consejos prácticos para mejorar la eficiencia."
+      },
+      "title": "Cómo digitalizar la gestión de una pyme en 5 pasos",
+      "sections": [
+        {
+          "paragraphs": [
+            "La digitalización ya no es una opción, es una necesidad para cualquier pyme que quiera mantenerse competitiva. Muchas pequeñas empresas han funcionado durante años con procesos manuales, documentos en papel y herramientas dispersas que complican el día a día. Este artículo pretende ser una guía detallada para que cualquier gestor o propietario pueda iniciar la transformación digital con confianza. Desde la planificación inicial hasta la implantación de herramientas y la formación del equipo, te explicamos cómo dar el paso hacia un modelo de gestión más eficiente y orientado al futuro."
+          ]
+        },
+        {
+          "heading": "1. Analiza el estado actual y define objetivos",
+          "paragraphs": [
+            "Antes de adquirir software o contratar servicios, es esencial entender cómo funciona actualmente la empresa. Realiza un inventario de procesos: contabilidad, gestión de clientes, control de stock, tareas administrativas y comunicación interna. Identifica los puntos débiles y aquellas actividades que generan más trabajo manual. A continuación, define objetivos concretos de digitalización, como reducir el tiempo de facturación, mejorar la trazabilidad de los pedidos o aumentar la satisfacción del cliente. Estos objetivos deben ser medibles y estar alineados con la estrategia global de la compañía. Contar con indicadores clave de rendimiento permitirá valorar los avances y ajustar el plan cuando sea necesario."
+          ]
+        },
+        {
+          "heading": "2. Elige las herramientas adecuadas",
+          "paragraphs": [
+            "El mercado ofrece una gran variedad de herramientas digitales: gestores de facturación, CRMs, plataformas de comunicación, sistemas de gestión de proyectos y aplicaciones de comercio electrónico, entre otras. El objetivo no es adquirir la solución más cara, sino aquella que mejor se adapte a los procesos y al presupuesto de la pyme. Prioriza las aplicaciones en la nube, que permiten acceder a la información desde cualquier lugar y reducir los costes de infraestructura. Valora también la posibilidad de utilizar programas modulares que puedan crecer a medida que lo haga el negocio. Consulta opiniones de otros usuarios, solicita demostraciones y asegúrate de que la herramienta cumple con la normativa vigente en materia de protección de datos y factura electrónica."
+          ]
+        },
+        {
+          "heading": "3. Integra los sistemas y automatiza procesos",
+          "paragraphs": [
+            "Una vez seleccionadas las herramientas, el siguiente paso es garantizar que todas trabajen de manera coordinada. Las integraciones permiten que los datos circulen sin errores ni duplicidades. Por ejemplo, el CRM puede estar conectado con el programa de facturación para que las ventas se reflejen automáticamente en la contabilidad. También se pueden automatizar tareas como el envío de correos de seguimiento, la generación de informes o la sincronización de stock entre la tienda física y la online. Dedica tiempo a definir los flujos de información y utiliza APIs o conectores proporcionados por los proveedores. Una buena integración no solo ahorra tiempo, sino que ofrece una visión global del negocio, facilitando la toma de decisiones basada en datos."
+          ]
+        },
+        {
+          "heading": "4. Forma al equipo y promueve la cultura digital",
+          "paragraphs": [
+            "La tecnología por sí sola no garantiza el éxito. Es fundamental que las personas que la utilizarán se sientan cómodas y entiendan las ventajas del cambio. Organiza sesiones de formación adaptadas a cada departamento y crea materiales de apoyo como manuales o vídeos breves. Promueve una cultura digital donde el aprendizaje continuo sea valorado y los errores se consideren una oportunidad de mejora. Implica a los trabajadores en el proceso, pidiendo su opinión y permitiéndoles proponer ideas. Cuando el equipo ve que la digitalización facilita su trabajo y elimina tareas repetitivas, la adopción es mucho más rápida y natural."
+          ]
+        },
+        {
+          "heading": "5. Mide resultados y ajusta la estrategia",
+          "paragraphs": [
+            "La transformación digital es un camino continuo. Tras implantar las herramientas y formar al equipo, es importante establecer un sistema de seguimiento que permita medir el impacto. Utiliza indicadores como el tiempo de respuesta a los clientes, el número de errores en la facturación o el coste de gestión por proyecto. Compara estos valores con los objetivos iniciales y detecta áreas de mejora. Puede ser necesario añadir nuevas funcionalidades, cambiar de proveedor o reforzar la formación en determinados puntos. La flexibilidad es clave: la digitalización no es un proyecto con principio y fin, sino una evolución constante que debe acompañar el crecimiento del negocio."
+          ]
+        },
+        {
+          "heading": "Beneficios adicionales de la digitalización",
+          "paragraphs": [
+            "Además de optimizar procesos, la digitalización aporta una serie de beneficios transversales. Permite trabajar de manera colaborativa, independientemente de la ubicación de los miembros del equipo, y facilita el acceso a nuevas oportunidades de negocio a través de Internet. La disponibilidad de datos en tiempo real mejora la toma de decisiones y reduce los riesgos. También contribuye a una imagen de marca más profesional e innovadora, lo que puede atraer nuevos clientes y partners. Por último, muchas herramientas digitales están preparadas para cumplir con normativas como el RGPD o VeriFactu, lo que simplifica el cumplimiento legal y evita sanciones."
+          ]
+        },
+        {
+          "heading": "Conclusión",
+          "paragraphs": [
+            "Digitalizar una pyme no tiene por qué ser un proceso traumático. Con una planificación adecuada y el apoyo de profesionales, es posible transformar la empresa de forma gradual y rentable. Lo importante es comenzar con objetivos claros, elegir las herramientas correctas e implicar a todo el equipo en el cambio. En JCT Agency hemos ayudado a numerosas empresas a dar este paso, y sabemos que los resultados llegan cuando la tecnología se combina con una visión estratégica. Si estás preparado para modernizar la gestión de tu negocio, la digitalización es el camino que te permitirá crecer y afrontar con garantías los retos del futuro."
+          ]
+        }
+      ]
+    },
+    "seo": {
+      "meta": {
+        "title": "Optimización SEO para pymes: guía completa | JCT Agency",
+        "description": "Guía SEO para pymes con técnicas para posicionar tu web en Google, atraer clientes locales y optimizar contenidos."
+      },
+      "title": "Optimización SEO para pymes: guía completa",
+      "sections": [
+        {
+          "paragraphs": [
+            "El posicionamiento orgánico en buscadores es uno de los pilares para generar tráfico cualificado hacia tu web sin depender exclusivamente de la publicidad de pago. Para una pyme, invertir en SEO significa establecer una base sólida que le permita competir con empresas más grandes y llegar a nuevos clientes potenciales. En esta guía profundizamos en las principales estrategias que puedes aplicar desde hoy mismo. El artículo está pensado como referencia completa: encontrarás recomendaciones prácticas, ejemplos reales y consejos sobre cómo implementarlas con recursos limitados. El objetivo es que puedas entender cada paso y llevarlo a la práctica sin necesidad de conocimientos técnicos avanzados."
+          ]
+        },
+        {
+          "heading": "1. Investigación de palabras clave",
+          "paragraphs": [
+            "Antes de redactar cualquier contenido es imprescindible saber qué términos utilizan tus clientes cuando buscan información relacionada con tu producto o servicio. Empieza elaborando una lista de posibles palabras y expresiones, incluyendo sinónimos y consultas de cola larga. Herramientas como Google Keyword Planner, Ubersuggest o AnswerThePublic permiten conocer el volumen de búsquedas, la dificultad y las tendencias. Dedica tiempo a entender la intención de cada búsqueda: no es lo mismo “gestoría para autónomos en Barcelona” que “cómo llevar la contabilidad de un autónomo”. Esta fase te servirá para crear contenido que responda exactamente a lo que necesita el usuario, mejorando la relevancia y aumentando las opciones de aparecer en los primeros resultados de Google."
+          ]
+        },
+        {
+          "heading": "2. Contenido de calidad y estrategia editorial",
+          "paragraphs": [
+            "Una vez identificadas las palabras clave, es momento de desarrollar una estrategia editorial. El contenido debe ser útil, original y centrado en resolver problemas reales. Planifica un calendario de publicaciones que combine artículos informativos, guías y casos de éxito. Es recomendable mantener una estructura clara con títulos, subtítulos y listas que faciliten la lectura. Incluye imágenes optimizadas con textos alternativos descriptivos y, siempre que sea posible, añade ejemplos propios de tu actividad empresarial. Recuerda que la actualización periódica del contenido es clave: Google valora las webs que se mantienen activas y aportan novedades de forma constante. Además, una buena estrategia editorial favorece que otras webs enlacen a tus artículos, incrementando la autoridad del dominio."
+          ]
+        },
+        {
+          "heading": "3. SEO local y ficha de Google Business",
+          "paragraphs": [
+            "Si tu negocio tiene una ubicación física o presta servicios en una zona geográfica concreta, trabajar el SEO local es imprescindible. El primer paso es crear y optimizar la ficha de Google Business Profile, asegurándote de que la información de contacto, horarios y categorías sea correcta. Anima a tus clientes a dejar reseñas y respóndelas siempre, ya que son un factor de posicionamiento y refuerzan la confianza. En la web, incluye tu ubicación en las páginas de servicios y en el pie de página, utilizando datos estructurados para que los buscadores entiendan mejor dónde operas. Publicar contenido relacionado con tu ciudad o comarca también ayuda a atraer tráfico cualificado que busca soluciones cerca de su ubicación."
+          ]
+        },
+        {
+          "heading": "4. Optimización técnica de la web",
+          "paragraphs": [
+            "Una web rápida y sin errores es fundamental para que tu esfuerzo en contenidos dé resultados. Revisa periódicamente la velocidad de carga con herramientas como PageSpeed Insights o Lighthouse y aplica las mejoras recomendadas: compresión de imágenes, minificación de recursos e implementación de caché. La web debe ser totalmente responsive, adaptarse a móviles y tabletas, y utilizar el protocolo HTTPS para garantizar la seguridad. También es importante disponer de un mapa del sitio y un archivo robots.txt correctamente configurados para que Google pueda rastrear las páginas sin problemas. Los errores 404 y los enlaces rotos deben solucionarse rápidamente para evitar penalizaciones y una mala experiencia de usuario."
+          ]
+        },
+        {
+          "heading": "5. Estrategia de enlazado interno",
+          "paragraphs": [
+            "Crear una red de enlaces interna coherente facilita que los buscadores entiendan la estructura de tu sitio y distribuye la autoridad entre las distintas páginas. Cada vez que publiques un nuevo artículo, enlázalo con contenido relacionado que ya exista en tu web. Esto prolonga el tiempo de sesión de los usuarios y reduce la tasa de rebote. Utiliza textos de anclaje descriptivos, evitando frases genéricas como “haz clic aquí”. Las páginas más importantes deberían recibir más enlaces internos, y es recomendable hacer un seguimiento regular para detectar oportunidades de enlazado que ayuden a posicionar palabras clave concretas. Un buen enlazado interno también sirve para guiar al usuario hacia la conversión, ya sea rellenar un formulario, descargar un recurso o contratar un servicio."
+          ]
+        },
+        {
+          "heading": "6. Link building y colaboraciones",
+          "paragraphs": [
+            "Los enlaces que provienen de otras webs siguen siendo uno de los factores de posicionamiento más relevantes. Para una pyme, la clave es conseguir backlinks de calidad sin recurrir a prácticas dudosas. Puedes colaborar con blogs de tu sector, participar en eventos y publicar notas de prensa en medios locales. Los directorios empresariales, asociaciones profesionales o proveedores también pueden enlazar tu sitio si ofreces contenido de interés. Prioriza la calidad sobre la cantidad: un solo enlace de una web con autoridad puede ser más valioso que decenas de baja calidad. Además, diversifica los textos de anclaje y evita un patrón artificial que pueda levantar sospechas en los algoritmos de Google."
+          ]
+        },
+        {
+          "heading": "7. Experiencia de usuario y Core Web Vitals",
+          "paragraphs": [
+            "Google ha incorporado las Core Web Vitals como indicador clave de la experiencia de usuario. Estos parámetros miden la velocidad de carga, la estabilidad visual y la interactividad de la página. Para optimizarlos, reduce los scripts innecesarios, utiliza fuentes web eficientes y reserva espacio para las imágenes para evitar movimientos inesperados. Una experiencia de usuario positiva no solo ayuda al posicionamiento, sino que también aumenta la probabilidad de conversión. Recuerda que el SEO y la usabilidad van de la mano: cuando el usuario encuentra rápidamente lo que busca y navega sin dificultades, es más probable que vuelva y recomiende tu web."
+          ]
+        },
+        {
+          "heading": "8. Analítica y mejora continua",
+          "paragraphs": [
+            "Ninguna estrategia SEO está completa sin un sistema de medición que permita evaluar los resultados. Configura Google Analytics y Google Search Console para monitorizar el tráfico, las palabras clave que generan visitas y el comportamiento de los usuarios. Establece objetivos claros, como conversiones o descargas, y realiza un seguimiento periódico para identificar qué páginas funcionan mejor. La analítica también sirve para detectar contenido obsoleto o palabras clave emergentes que vale la pena trabajar. El SEO es un proceso iterativo: analiza, aprende y aplica mejoras constantes para mantenerte por delante de la competencia."
+          ]
+        },
+        {
+          "heading": "9. Automatización y herramientas de apoyo",
+          "paragraphs": [
+            "Aunque muchas acciones SEO se pueden hacer manualmente, utilizar herramientas de automatización puede ahorrar tiempo y recursos. Plataformas como Screaming Frog, SEMrush o Ahrefs permiten auditar la web, detectar errores técnicos y monitorizar la estrategia de link building. También puedes programar alertas para saber cuándo un competidor publica nuevo contenido o recibe un enlace relevante. La automatización no sustituye la creatividad ni la planificación estratégica, pero sí facilita la gestión diaria y permite concentrarte en tareas de mayor valor, como la creación de contenido o el desarrollo de nuevos servicios."
+          ]
+        },
+        {
+          "heading": "10. Conclusiones y próximos pasos",
+          "paragraphs": [
+            "Implementar una estrategia SEO efectiva requiere constancia y una visión a largo plazo. Las pymes que apuestan por esta disciplina consiguen una presencia online más sólida, un flujo constante de clientes potenciales y una imagen de marca reforzada. Comienza por los aspectos básicos: una buena investigación de palabras clave, contenido relevante y una web técnicamente optimizada. A medida que obtengas resultados, amplía las acciones con estrategias de link building, mejoras de experiencia de usuario y automatización. Recuerda que el SEO es una carrera de fondo: cada acción suma y, con perseverancia, tu negocio puede destacar en un entorno digital cada vez más competitivo."
+          ]
+        }
+      ]
+    },
+    "software": {
+      "meta": {
+        "title": "Beneficios del software a medida para gestorías y pymes | JCT Agency",
+        "description": "Ventajas del desarrollo de software a medida para optimizar procesos en gestorías y pequeñas empresas."
+      },
+      "title": "Beneficios del software a medida para gestorías y pymes",
+      "sections": [
+        {
+          "paragraphs": [
+            "El software a medida se ha convertido en una herramienta clave para gestorías y pymes que necesitan soluciones específicas para sus procesos internos. A diferencia de las herramientas genéricas, el desarrollo personalizado permite adaptar las funcionalidades exactas a las necesidades del negocio, integrándose con otros sistemas y garantizando la seguridad de los datos. En este artículo repasamos los principales beneficios y cómo puede impactar directamente en la productividad de la empresa."
+          ]
+        },
+        {
+          "heading": "1. Automatización de procesos repetitivos",
+          "paragraphs": [
+            "Con software a medida es posible automatizar tareas que antes requerían horas de trabajo manual. Desde la generación de documentos fiscales hasta el envío de avisos a clientes, la tecnología permite reducir errores y liberar tiempo para que los equipos se enfoquen en tareas de mayor valor."
+          ]
+        },
+        {
+          "heading": "2. Integración con otras herramientas",
+          "paragraphs": [
+            "Las gestorías y pymes suelen utilizar múltiples aplicaciones: programas de contabilidad, CRMs, plataformas de facturación o herramientas de firma digital. Un software a medida permite integrar todas estas soluciones en un único entorno, evitando la duplicación de datos y mejorando la trazabilidad de la información."
+          ]
+        },
+        {
+          "heading": "3. Cumplimiento normativo asegurado",
+          "paragraphs": [
+            "El marco legal evoluciona constantemente y obliga a las empresas a mantenerse al día. Desarrollar software a medida garantiza que todas las actualizaciones normativas se apliquen de forma centralizada, reduciendo el riesgo de sanciones y facilitando auditorías internas."
+          ]
+        },
+        {
+          "heading": "4. Experiencia de usuario personalizada",
+          "paragraphs": [
+            "Cada equipo trabaja de forma diferente. Un software a medida puede diseñarse para que la experiencia de usuario sea intuitiva y adaptada al flujo de trabajo de cada departamento, incrementando la adopción y la satisfacción de los empleados."
+          ]
+        },
+        {
+          "heading": "5. Escalabilidad y flexibilidad",
+          "paragraphs": [
+            "A medida que la gestoría o la pyme crece, también lo hacen sus necesidades. El software a medida permite añadir nuevas funcionalidades, perfiles de usuario o integraciones sin tener que cambiar de herramienta, asegurando una inversión a largo plazo."
+          ]
+        },
+        {
+          "heading": "Conclusión",
+          "paragraphs": [
+            "Invertir en software a medida es apostar por una solución que acompaña el crecimiento del negocio. En JCT Agency diseñamos y desarrollamos aplicaciones adaptadas a cada proyecto, con un enfoque en la seguridad, la usabilidad y el cumplimiento legal."
+          ]
+        }
+      ]
+    },
+    "verifactu": {
+      "meta": {
+        "title": "Guía práctica para gestorías sobre Veri*Factu | JCT Agency",
+        "description": "Aspectos clave de Veri*Factu para gestorías: obligaciones, plazos y cómo adaptarse a la normativa."
+      },
+      "title": "Guía práctica para gestorías sobre Veri*Factu",
+      "sections": [
+        {
+          "paragraphs": [
+            "Veri*Factu es el sistema impulsado por la AEAT para garantizar la integridad y autenticidad de los registros de facturación. Para las gestorías, conocer sus detalles es esencial para asesorar correctamente a sus clientes y adaptar los procesos internos."
+          ]
+        },
+        {
+          "heading": "1. ¿Qué es Veri*Factu?",
+          "paragraphs": [
+            "Es un marco normativo que obliga a enviar las facturas a la AEAT en tiempo real, garantizando que no puedan manipularse posteriormente. Cada factura genera un código hash y un registro inalterable."
+          ]
+        },
+        {
+          "heading": "2. ¿Quién debe cumplir la normativa?",
+          "paragraphs": [
+            "Todas las empresas y profesionales que emiten facturas deben adaptar sus sistemas a Veri*Factu antes de la entrada en vigor obligatoria. Las gestorías deben prepararse para ofrecer herramientas que cumplan con estos requisitos."
+          ]
+        },
+        {
+          "heading": "3. ¿Qué funcionalidades debe tener el software?",
+          "paragraphs": [
+            "El programa debe generar códigos QR tributarios, conservar registros seguros, evitar la manipulación de asientos y permitir el envío inmediato a la AEAT. También debe registrar eventos y asegurar copias de seguridad."
+          ]
+        },
+        {
+          "heading": "4. ¿Cómo puede ayudar una gestoría a sus clientes?",
+          "paragraphs": [
+            "Implementando un software certificado como Avero, ofreciendo formación sobre la nueva normativa y monitorizando que todas las facturas se transmitan correctamente."
+          ]
+        },
+        {
+          "heading": "5. Beneficios de adaptarse pronto",
+          "paragraphs": [
+            "Adoptar Veri*Factu con tiempo permite evitar sanciones, mejorar la relación con los clientes y posicionar a la gestoría como referente en cumplimiento normativo y transformación digital."
+          ]
+        }
+      ]
+    },
+    "saas": {
+      "meta": {
+        "title": "¿Por qué un SaaS es mejor que un software tradicional? | JCT Agency",
+        "description": "Comparativa entre software SaaS y soluciones tradicionales para decidir la mejor opción para tu negocio."
+      },
+      "title": "¿Por qué un SaaS es mejor que un software tradicional?",
+      "sections": [
+        {
+          "paragraphs": [
+            "Elegir entre un software SaaS (Software as a Service) y una solución tradicional instalada en servidores propios es una decisión clave para muchas empresas. A continuación analizamos las diferencias principales para ayudarte a tomar la mejor decisión."
+          ]
+        },
+        {
+          "heading": "1. Coste inicial y mantenimiento",
+          "paragraphs": [
+            "El modelo SaaS funciona bajo suscripción y evita una gran inversión inicial en licencias e infraestructura. El software tradicional requiere equipos, instalaciones y actualizaciones costosas."
+          ]
+        },
+        {
+          "heading": "2. Actualizaciones y seguridad",
+          "paragraphs": [
+            "Con SaaS, el proveedor se encarga de las actualizaciones automáticas, las mejoras de seguridad y las copias de seguridad. En un entorno tradicional, la empresa debe gestionar estos procesos manualmente."
+          ]
+        },
+        {
+          "heading": "3. Escalabilidad",
+          "paragraphs": [
+            "El SaaS permite ampliar o reducir usuarios y funcionalidades con facilidad. Las soluciones tradicionales exigen planificación e inversión en hardware adicional."
+          ]
+        },
+        {
+          "heading": "4. Accesibilidad",
+          "paragraphs": [
+            "Un software SaaS es accesible desde cualquier dispositivo conectado a Internet, facilitando el teletrabajo y la colaboración. El software tradicional suele limitarse a la oficina o requiere configuraciones VPN complejas."
+          ]
+        },
+        {
+          "heading": "5. Integraciones",
+          "paragraphs": [
+            "Muchas soluciones SaaS ofrecen APIs y conectores para integrarse con otras herramientas del mercado. Las aplicaciones tradicionales pueden necesitar desarrollos a medida y más tiempo para lograr la misma conexión."
+          ]
+        },
+        {
+          "heading": "Conclusión",
+          "paragraphs": [
+            "El modelo SaaS destaca por su flexibilidad, seguridad y rapidez de despliegue. Aun así, es importante analizar las necesidades específicas de cada empresa para escoger la solución que aporte más valor a largo plazo."
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- integrate react-i18next with language-aware routing and persistence across the SPA
- extract page copy into Catalan and Spanish locale dictionaries and update all pages to use translation keys
- add a persistent header language selector that keeps navigation and metadata in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df89b6a1548323b286be1796c923ee