### PR TITLE
Fix ESLint warning in header component

### DIFF
--- a/src/components/components/header.js
+++ b/src/components/components/header.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Navbar, Nav, Container } from 'react-bootstrap';
-import InlineCTAGroup from '../cta/InlineCTAGroup';
 import logoImage from '../img/LOGO JCTAGENCY.png';
 
 const navItems = [


### PR DESCRIPTION
## Summary
- remove the unused InlineCTAGroup import from the header component to resolve the CI lint error

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df996f7c84832382b0343d988c8c00