### PR TITLE
Update RegIT branding assets

### DIFF
--- a/src/components/components/header.js
+++ b/src/components/components/header.js
@@ -55,7 +55,7 @@ const Header = () => {
         >
           <a href="/consultoria" onClick={closeMenu}>Consultoría</a>
           <a href="/avero" onClick={closeMenu}>Avero</a>
-          <a href="/regit" onClick={closeMenu}>REGIT</a>
+          <a href="/regit" onClick={closeMenu}>RegIT</a>
           <a href="/constructpro" onClick={closeMenu}>ConstructPro</a>
           <a
             href={whatsappDiagnostic}

--- a/src/components/img/regit-logo.svg
+++ b/src/components/img/regit-logo.svg
@@ -1,5 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" role="img" aria-label="Regit logo">
-  <rect width="240" height="240" rx="32" fill="#111111"/>
-  <path d="M70 60h52c36 0 62 24 62 60 0 36-26 60-62 60H70V60zm48 40H104v80h14c22 0 38-16 38-40 0-24-16-40-38-40z" fill="#ffffff"/>
-  <circle cx="168" cy="140" r="20" fill="#ffffff"/>
+  <g fill="none" stroke="#4a4a4a" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M190 70 A80 80 0 1 0 190 170" stroke-width="18"/>
+    <path d="M190 120 H150" stroke-width="18"/>
+    <path d="M90 125 L112 147 L150 100" stroke-width="14"/>
+  </g>
+  <g stroke="#4a4a4a" stroke-width="8" stroke-linecap="round">
+    <line x1="120" y1="52" x2="120" y2="40"/>
+    <line x1="84" y1="62" x2="78" y2="50"/>
+    <line x1="56" y1="90" x2="44" y2="84"/>
+    <line x1="46" y1="126" x2="34" y2="126"/>
+    <line x1="56" y1="162" x2="44" y2="168"/>
+    <line x1="84" y1="190" x2="78" y2="202"/>
+    <line x1="120" y1="200" x2="120" y2="212"/>
+  </g>
 </svg>

--- a/src/components/img/regit-wordmark.svg
+++ b/src/components/img/regit-wordmark.svg
@@ -1,5 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 140" role="img" aria-label="Regit wordmark">
-  <rect width="520" height="140" rx="24" fill="#f4f4f4"/>
-  <text x="40" y="88" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="700" fill="#111111">REGIT</text>
-  <text x="40" y="118" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#4b4b4b">Control horario sencillo</text>
+  <text x="40" y="88" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="700" fill="#4a4a4a">RE</text>
+  <text x="350" y="88" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="700" fill="#4a4a4a">IT</text>
+  <g transform="translate(205 10) scale(0.5)" fill="none" stroke="#4a4a4a" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M190 70 A80 80 0 1 0 190 170" stroke-width="18"/>
+    <path d="M190 120 H150" stroke-width="18"/>
+    <path d="M90 125 L112 147 L150 100" stroke-width="14"/>
+    <g stroke="#4a4a4a" stroke-width="8" stroke-linecap="round">
+      <line x1="120" y1="52" x2="120" y2="40"/>
+      <line x1="84" y1="62" x2="78" y2="50"/>
+      <line x1="56" y1="90" x2="44" y2="84"/>
+      <line x1="46" y1="126" x2="34" y2="126"/>
+      <line x1="56" y1="162" x2="44" y2="168"/>
+      <line x1="84" y1="190" x2="78" y2="202"/>
+      <line x1="120" y1="200" x2="120" y2="212"/>
+    </g>
+  </g>
 </svg>


### PR DESCRIPTION
### Motivation
- Integrate the new RegIT program branding (logo and isologo) into the site and adjust the header menu label casing to match the program identity.

### Description
- Change the header navigation label from `REGIT` to `RegIT` in `src/components/components/header.js`.
- Replace `src/components/img/regit-logo.svg` with a new stroke-based isologo SVG using neutral strokes (`#4a4a4a`).
- Replace `src/components/img/regit-wordmark.svg` with a new wordmark SVG that separates `RE` and `IT` and embeds the isologo between them at reduced scale.
- Visual assets were updated as plain SVGs so layout and accessibility attributes (`role`, `aria-label`) are preserved.

### Testing
- Started the development server with `npm start` and the app compiled successfully (webpack compiled OK). 
- Ran a Playwright script to navigate to `/regit` and capture a screenshot, which produced an artifact confirming the visual updates. 
- No automated unit tests were run for these visual asset changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697209b28b8c83238419968139d16df5)